### PR TITLE
refactor: achieve consistency with other SDKs

### DIFF
--- a/http-signature-utils/Cargo.toml
+++ b/http-signature-utils/Cargo.toml
@@ -21,6 +21,7 @@ sha2 = "0.10"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt", "macros"] }
 env_logger = "0.11.8"
+tempfile = "3.8"
 
 [[example]]
 name = "generate_signature"

--- a/http-signature-utils/src/error.rs
+++ b/http-signature-utils/src/error.rs
@@ -1,6 +1,6 @@
-use thiserror::Error;
-use std::io;
 use base64::DecodeError;
+use std::io;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum HttpSignatureError {
@@ -26,4 +26,4 @@ pub enum HttpSignatureError {
     Other(String),
 }
 
-pub type Result<T> = std::result::Result<T, HttpSignatureError>; 
+pub type Result<T> = std::result::Result<T, HttpSignatureError>;

--- a/http-signature-utils/src/jwk.rs
+++ b/http-signature-utils/src/jwk.rs
@@ -1,7 +1,5 @@
-use base64::{
-    engine::general_purpose::URL_SAFE_NO_PAD,
-    Engine,
-};
+use crate::error::{HttpSignatureError, Result};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
@@ -9,7 +7,6 @@ use serde_json::json;
 use std::fs;
 use std::path::Path;
 use thiserror::Error;
-use crate::error::{HttpSignatureError, Result};
 
 #[derive(Debug, Error)]
 pub enum JwkError {
@@ -57,7 +54,9 @@ impl Jwk {
 
     pub fn validate(&self) -> Result<()> {
         if self.crv != "Ed25519" || self.kty != "OKP" || self.x.is_empty() {
-            return Err(HttpSignatureError::Jwk(JwkError::InvalidKeyType.to_string()));
+            return Err(HttpSignatureError::Jwk(
+                JwkError::InvalidKeyType.to_string(),
+            ));
         }
         Ok(())
     }
@@ -79,8 +78,7 @@ impl Jwk {
     }
 
     pub fn save_jwks(jwks_json: &str, jwks_path: &Path) -> Result<()> {
-        fs::write(jwks_path, jwks_json)
-            .map_err(HttpSignatureError::from)?;
+        fs::write(jwks_path, jwks_json).map_err(HttpSignatureError::from)?;
         Ok(())
     }
 }

--- a/http-signature-utils/src/lib.rs
+++ b/http-signature-utils/src/lib.rs
@@ -1,11 +1,11 @@
+pub mod error;
 pub mod jwk;
 pub mod signatures;
-pub mod validation;
 pub mod utils;
-pub mod error;
+pub mod validation;
 
-pub use jwk::{Jwk, JwkError};
-pub use signatures::{create_signature_headers, SignOptions, SignatureHeaders};
-pub use validation::{validate_signature, ValidationOptions};
-pub use utils::load_or_generate_key;
 pub use error::{HttpSignatureError, Result};
+pub use jwk::{Jwk, JwkError};
+pub use signatures::{SignOptions, SignatureHeaders, create_signature_headers};
+pub use utils::load_or_generate_key;
+pub use validation::{ValidationOptions, validate_signature};

--- a/http-signature-utils/src/signatures.rs
+++ b/http-signature-utils/src/signatures.rs
@@ -1,8 +1,8 @@
-use base64::{engine::general_purpose::STANDARD, Engine};
+use crate::error::Result;
+use base64::{Engine, engine::general_purpose::STANDARD};
 use ed25519_dalek::{Signer, SigningKey};
 use http::Request;
 use serde::{Deserialize, Serialize};
-use crate::error::Result;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SignatureHeaders {
@@ -74,13 +74,11 @@ fn create_signature_base_string(
         keyid
     );
     parts.push(format!("\"@signature-params\": {}", sig_params));
-    
+
     parts.join("\n")
 }
 
-pub fn create_signature_headers(
-    options: SignOptions<'_>,
-) -> Result<SignatureHeaders> {
+pub fn create_signature_headers(options: SignOptions<'_>) -> Result<SignatureHeaders> {
     let mut components = vec!["@method", "@target-uri", "content-type"];
 
     if options.request.headers().get("Authorization").is_some() {

--- a/http-signature-utils/src/utils.rs
+++ b/http-signature-utils/src/utils.rs
@@ -1,11 +1,11 @@
-use base64::{engine::general_purpose::STANDARD, Engine};
+use crate::error::{HttpSignatureError, Result};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use ed25519_dalek::SigningKey;
-use pem::{parse, encode, Pem};
-use pkcs8::{der::Decode, PrivateKeyInfo};
+use pem::{Pem, encode, parse};
+use pkcs8::{PrivateKeyInfo, der::Decode};
 use rand::rngs::OsRng;
 use std::fs;
 use std::path::Path;
-use crate::error::{HttpSignatureError, Result};
 
 pub fn load_or_generate_key(path: &Path) -> Result<SigningKey> {
     if path.exists() {
@@ -23,17 +23,20 @@ pub fn load_or_generate_key(path: &Path) -> Result<SigningKey> {
             return Err(HttpSignatureError::Pem("Not a PRIVATE KEY".to_string()));
         }
 
-        let private_key_info = PrivateKeyInfo::from_der(pem.contents()).map_err(|e| HttpSignatureError::Pkcs8(e.to_string()))?;
+        let private_key_info = PrivateKeyInfo::from_der(pem.contents())
+            .map_err(|e| HttpSignatureError::Pkcs8(e.to_string()))?;
         let raw = private_key_info.private_key;
 
-        let raw_private_key: [u8; 32] = raw[2..].try_into().map_err(|_| HttpSignatureError::InvalidPrivateKeyLength)?;
+        let raw_private_key: [u8; 32] = raw[2..]
+            .try_into()
+            .map_err(|_| HttpSignatureError::InvalidPrivateKeyLength)?;
 
         let signing_key = SigningKey::from_bytes(&raw_private_key);
         Ok(signing_key)
     } else {
         let mut csprng = OsRng {};
         let signing_key = SigningKey::generate(&mut csprng);
-        
+
         let pem = Pem::new(
             "PRIVATE KEY",
             // We need to prepend the Ed25519 OID and key length
@@ -45,14 +48,126 @@ pub fn load_or_generate_key(path: &Path) -> Result<SigningKey> {
                 0x06, 0x03, 0x2B, 0x65, 0x70, // OID 1.3.101.112 (Ed25519)
                 0x04, 0x22, // OCTET STRING, 34 bytes
                 0x04, 0x20, // OCTET STRING, 32 bytes (the actual key)
-            ].iter()
+            ]
+            .iter()
             .chain(signing_key.to_bytes().iter())
             .copied()
-            .collect::<Vec<u8>>()
+            .collect::<Vec<u8>>(),
         );
-        
+
         let pem_string = encode(&pem);
         fs::write(path, pem_string)?;
         Ok(signing_key)
     }
-} 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_generate_new_key() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("test_key.pem");
+
+        // Key should not exist initially
+        assert!(!path.exists());
+
+        // Generate a new key
+        let key1 = load_or_generate_key(&path).unwrap();
+
+        // File should now exist
+        assert!(path.exists());
+
+        // Loading the same key should return the same key
+        let key2 = load_or_generate_key(&path).unwrap();
+        assert_eq!(key1.to_bytes(), key2.to_bytes());
+    }
+
+    #[test]
+    fn test_load_existing_key() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("test_key.pem");
+
+        // Generate a key first
+        let original_key = load_or_generate_key(&path).unwrap();
+
+        // Load the existing key
+        let loaded_key = load_or_generate_key(&path).unwrap();
+
+        // Should be the same key
+        assert_eq!(original_key.to_bytes(), loaded_key.to_bytes());
+    }
+
+    #[test]
+    fn test_invalid_pem_format() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("invalid.pem");
+
+        // Write invalid PEM content
+        let mut file = fs::File::create(&path).unwrap();
+        file.write_all(b"-----BEGIN INVALID-----\ninvalid content\n-----END INVALID-----")
+            .unwrap();
+
+        let result = load_or_generate_key(&path);
+        assert!(matches!(result, Err(HttpSignatureError::Pem(_))));
+    }
+
+    #[test]
+    fn test_wrong_pem_tag() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("wrong_tag.pem");
+
+        // Write PEM with wrong tag
+        let mut file = fs::File::create(&path).unwrap();
+        file.write_all(b"-----BEGIN PUBLIC KEY-----\ninvalid content\n-----END PUBLIC KEY-----")
+            .unwrap();
+
+        let result = load_or_generate_key(&path);
+        assert!(matches!(result, Err(HttpSignatureError::Pem(_))));
+    }
+
+    #[test]
+    fn test_base64_encoded_pem() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("test_key.pem");
+
+        // Generate a key first
+        let original_key = load_or_generate_key(&path).unwrap();
+
+        // Read the PEM content and base64 encode it
+        let pem_content = fs::read_to_string(&path).unwrap();
+        let encoded = STANDARD.encode(pem_content.as_bytes());
+
+        // Write the base64 encoded content back
+        fs::write(&path, encoded).unwrap();
+
+        // Should still be able to load the key
+        let loaded_key = load_or_generate_key(&path).unwrap();
+        assert_eq!(original_key.to_bytes(), loaded_key.to_bytes());
+    }
+
+    #[test]
+    fn test_key_persistence() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("test_key.pem");
+
+        // Generate a key
+        let key1 = load_or_generate_key(&path).unwrap();
+
+        // Verify the file contains valid PEM
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("-----BEGIN PRIVATE KEY-----"));
+        assert!(content.contains("-----END PRIVATE KEY-----"));
+
+        // Parse the PEM to verify it's valid
+        let pem = parse(&content).unwrap();
+        assert_eq!(pem.tag(), "PRIVATE KEY");
+
+        // Load the key again to verify it's the same
+        let key2 = load_or_generate_key(&path).unwrap();
+        assert_eq!(key1.to_bytes(), key2.to_bytes());
+    }
+}

--- a/op-client/src/api.rs
+++ b/op-client/src/api.rs
@@ -42,7 +42,6 @@ pub mod authenticated {
             get_quote(self.client, quote_url, access_token).await
         }
     }
-    //TODO Add public incoming payment as unauth resource
     pub struct IncomingPaymentResource<'a> {
         client: &'a AuthenticatedOpenPaymentsClient,
     }

--- a/op-client/src/client.rs
+++ b/op-client/src/client.rs
@@ -11,7 +11,6 @@ pub struct AuthenticatedOpenPaymentsClient {
     pub http_client: ReqwestClient,
     pub config: ClientConfig,
     pub signing_key: SigningKey,
-    pub access_token: Option<String>,
 }
 
 impl BaseClient for AuthenticatedOpenPaymentsClient {
@@ -39,7 +38,6 @@ impl AuthenticatedOpenPaymentsClient {
             http_client,
             config,
             signing_key,
-            access_token: None,
         })
     }
 }

--- a/op-client/src/grant.rs
+++ b/op-client/src/grant.rs
@@ -10,12 +10,11 @@ pub(crate) async fn request_grant(
     auth_url: &str,
     grant: &GrantRequest,
 ) -> Result<GrantResponse> {
-    let url = format!("{}/", auth_url.trim_end_matches('/'));
     let body = serde_json::to_string(grant).map_err(OpClientError::Serde)?;
 
-    AuthenticatedRequest::new(client, Method::POST, url)
+    AuthenticatedRequest::new(client, Method::POST, auth_url.to_string())
         .with_body(body)
-        .build_and_execute()
+        .build_and_execute(None)
         .await
 }
 
@@ -23,6 +22,7 @@ pub(crate) async fn continue_grant(
     client: &AuthenticatedOpenPaymentsClient,
     continue_uri: &str,
     interact_ref: &str,
+    access_token: Option<&str>,
 ) -> Result<ContinueResponse> {
     let body = serde_json::to_string(&ContinueRequest {
         interact_ref: Some(interact_ref.to_string()),
@@ -31,15 +31,16 @@ pub(crate) async fn continue_grant(
 
     AuthenticatedRequest::new(client, Method::POST, continue_uri.to_string())
         .with_body(body)
-        .build_and_execute()
+        .build_and_execute(access_token)
         .await
 }
 
 pub(crate) async fn cancel_grant(
     client: &AuthenticatedOpenPaymentsClient,
     continue_uri: &str,
+    access_token: Option<&str>,
 ) -> Result<()> {
     AuthenticatedRequest::new(client, Method::DELETE, continue_uri.to_string())
-        .build_and_execute()
+        .build_and_execute(access_token)
         .await
 }

--- a/op-client/src/payments.rs
+++ b/op-client/src/payments.rs
@@ -1,45 +1,53 @@
 use crate::OpClientError;
 use crate::Result;
-use crate::client::AuthenticatedOpenPaymentsClient;
-use crate::request::AuthenticatedRequest;
+use crate::client::{AuthenticatedOpenPaymentsClient, BaseClient};
+use crate::request::{AuthenticatedRequest, UnauthenticatedRequest};
 use crate::types::{
     IncomingPayment, IncomingPaymentRequest, ListIncomingPaymentsResponse,
     ListOutgoingPaymentsResponse, OutgoingPayment, OutgoingPaymentRequest,
 };
+use crate::utils::join_url_paths;
+use op_types::resource::PublicIncomingPayment;
 use reqwest::Method;
+use url::Url;
 
 pub(crate) async fn create_incoming_payment(
     client: &AuthenticatedOpenPaymentsClient,
     resource_server_url: &str,
     req_body: &IncomingPaymentRequest,
+    access_token: Option<&str>,
 ) -> Result<IncomingPayment> {
-    let url = format!(
-        "{}/incoming-payments",
-        resource_server_url.trim_end_matches('/')
-    );
+    let url = join_url_paths(resource_server_url, "incoming-payments")?;
     let body = serde_json::to_string(req_body).map_err(OpClientError::Serde)?;
 
     AuthenticatedRequest::new(client, Method::POST, url)
         .with_body(body)
-        .build_and_execute()
+        .build_and_execute(access_token)
         .await
 }
 
 pub(crate) async fn get_incoming_payment(
     client: &AuthenticatedOpenPaymentsClient,
     payment_url: &str,
+    access_token: Option<&str>,
 ) -> Result<IncomingPayment> {
     AuthenticatedRequest::new(client, Method::GET, payment_url.to_string())
-        .build_and_execute()
+        .build_and_execute(access_token)
         .await
 }
 
 pub(crate) async fn complete_incoming_payment(
     client: &AuthenticatedOpenPaymentsClient,
     payment_url: &str,
+    access_token: Option<&str>,
 ) -> Result<IncomingPayment> {
-    AuthenticatedRequest::new(client, Method::POST, format!("{}/complete", payment_url))
-        .build_and_execute()
+    println!("Input payment URL: {}", payment_url);
+    let url = join_url_paths(payment_url, "complete")?;
+
+    println!("Completing payment at URL: {}", url);
+
+    AuthenticatedRequest::new(client, Method::POST, url)
+        .build_and_execute(access_token)
         .await
 }
 
@@ -50,25 +58,26 @@ pub(crate) async fn list_incoming_payments(
     cursor: Option<&str>,
     first: Option<u32>,
     last: Option<u32>,
+    access_token: Option<&str>,
 ) -> Result<ListIncomingPaymentsResponse> {
-    let mut url = format!(
-        "{}/incoming-payments?wallet-address={}",
-        resource_server_url.trim_end_matches('/'),
-        wallet_address
-    );
+    let mut url = Url::parse(&join_url_paths(resource_server_url, "incoming-payments")?)?;
+
+    url.query_pairs_mut()
+        .append_pair("wallet-address", wallet_address);
 
     if let Some(cursor) = cursor {
-        url.push_str(&format!("&cursor={}", cursor));
+        url.query_pairs_mut().append_pair("cursor", cursor);
     }
     if let Some(first) = first {
-        url.push_str(&format!("&first={}", first));
+        url.query_pairs_mut()
+            .append_pair("first", &first.to_string());
     }
     if let Some(last) = last {
-        url.push_str(&format!("&last={}", last));
+        url.query_pairs_mut().append_pair("last", &last.to_string());
     }
 
-    AuthenticatedRequest::new(client, Method::GET, url)
-        .build_and_execute()
+    AuthenticatedRequest::new(client, Method::GET, url.to_string())
+        .build_and_execute(access_token)
         .await
 }
 
@@ -76,25 +85,24 @@ pub(crate) async fn create_outgoing_payment(
     client: &AuthenticatedOpenPaymentsClient,
     resource_server_url: &str,
     req_body: &OutgoingPaymentRequest,
+    access_token: Option<&str>,
 ) -> Result<OutgoingPayment> {
-    let url = format!(
-        "{}/outgoing-payments",
-        resource_server_url.trim_end_matches('/')
-    );
+    let url = join_url_paths(resource_server_url, "outgoing-payments")?;
     let body = serde_json::to_string(req_body).map_err(OpClientError::Serde)?;
 
     AuthenticatedRequest::new(client, Method::POST, url)
         .with_body(body)
-        .build_and_execute()
+        .build_and_execute(access_token)
         .await
 }
 
 pub(crate) async fn get_outgoing_payment(
     client: &AuthenticatedOpenPaymentsClient,
     payment_url: &str,
+    access_token: Option<&str>,
 ) -> Result<OutgoingPayment> {
     AuthenticatedRequest::new(client, Method::GET, payment_url.to_string())
-        .build_and_execute()
+        .build_and_execute(access_token)
         .await
 }
 
@@ -105,24 +113,34 @@ pub(crate) async fn list_outgoing_payments(
     cursor: Option<&str>,
     first: Option<u32>,
     last: Option<u32>,
+    access_token: Option<&str>,
 ) -> Result<ListOutgoingPaymentsResponse> {
-    let mut url = format!(
-        "{}/outgoing-payments?wallet-address={}",
-        resource_server_url.trim_end_matches('/'),
-        wallet_address
-    );
+    let mut url = Url::parse(&join_url_paths(resource_server_url, "outgoing-payments")?)?;
+
+    url.query_pairs_mut()
+        .append_pair("wallet-address", wallet_address);
 
     if let Some(cursor) = cursor {
-        url.push_str(&format!("&cursor={}", cursor));
+        url.query_pairs_mut().append_pair("cursor", cursor);
     }
     if let Some(first) = first {
-        url.push_str(&format!("&first={}", first));
+        url.query_pairs_mut()
+            .append_pair("first", &first.to_string());
     }
     if let Some(last) = last {
-        url.push_str(&format!("&last={}", last));
+        url.query_pairs_mut().append_pair("last", &last.to_string());
     }
 
-    AuthenticatedRequest::new(client, Method::GET, url)
+    AuthenticatedRequest::new(client, Method::GET, url.to_string())
+        .build_and_execute(access_token)
+        .await
+}
+
+pub(crate) async fn get_public_incoming_payment<C: BaseClient>(
+    client: &C,
+    payment_url: &str,
+) -> Result<PublicIncomingPayment> {
+    UnauthenticatedRequest::new(client.http_client(), Method::GET, payment_url.to_string())
         .build_and_execute()
         .await
 }

--- a/op-client/src/quotes.rs
+++ b/op-client/src/quotes.rs
@@ -3,27 +3,30 @@ use crate::Result;
 use crate::client::AuthenticatedOpenPaymentsClient;
 use crate::request::AuthenticatedRequest;
 use crate::types::{Quote, QuoteRequest};
+use crate::utils::join_url_paths;
 use reqwest::Method;
 
 pub(crate) async fn create_quote(
     client: &AuthenticatedOpenPaymentsClient,
     resource_server_url: &str,
     req_body: &QuoteRequest,
+    access_token: Option<&str>,
 ) -> Result<Quote> {
-    let url = format!("{}/quotes", resource_server_url.trim_end_matches('/'));
+    let url = join_url_paths(resource_server_url, "quotes")?;
     let body = serde_json::to_string(req_body).map_err(OpClientError::Serde)?;
 
     AuthenticatedRequest::new(client, Method::POST, url)
         .with_body(body)
-        .build_and_execute()
+        .build_and_execute(access_token)
         .await
 }
 
 pub(crate) async fn get_quote(
     client: &AuthenticatedOpenPaymentsClient,
     quote_url: &str,
+    access_token: Option<&str>,
 ) -> Result<Quote> {
     AuthenticatedRequest::new(client, Method::GET, quote_url.to_string())
-        .build_and_execute()
+        .build_and_execute(access_token)
         .await
 }

--- a/op-client/src/request.rs
+++ b/op-client/src/request.rs
@@ -178,22 +178,6 @@ async fn execute_request<T: DeserializeOwned + 'static>(
             "Request failed: HTTP {}",
             resp.status()
         )));
-
-        /*
-
-
-        let response_body = resp.json().map_err(OpClientError::from)?;
-
-        return Err(OpError {
-            status: Some(resp.status().as_u16() as u8),
-            code: None,
-            validation_errors: None,
-            description: Some(OpClientError::Http(format!(
-                "Request failed: HTTP {}",
-                response_body
-            ))),
-        })
-         */
     }
 
     if resp.status() == reqwest::StatusCode::NO_CONTENT

--- a/op-client/src/token.rs
+++ b/op-client/src/token.rs
@@ -7,17 +7,19 @@ use reqwest::Method;
 pub(crate) async fn rotate_access_token(
     client: &AuthenticatedOpenPaymentsClient,
     token_manage_url: &str,
+    access_token: Option<&str>,
 ) -> Result<AccessTokenResponse> {
     AuthenticatedRequest::new(client, Method::POST, token_manage_url.to_string())
-        .build_and_execute()
+        .build_and_execute(access_token)
         .await
 }
 
 pub(crate) async fn revoke_access_token(
     client: &AuthenticatedOpenPaymentsClient,
     token_manage_url: &str,
+    access_token: Option<&str>,
 ) -> Result<()> {
     AuthenticatedRequest::new(client, Method::DELETE, token_manage_url.to_string())
-        .build_and_execute()
+        .build_and_execute(access_token)
         .await
 }

--- a/op-client/src/types.rs
+++ b/op-client/src/types.rs
@@ -9,7 +9,7 @@ pub use op_types::resource::{
     CreateIncomingPaymentRequest as IncomingPaymentRequest,
     CreateOutgoingPaymentRequest as OutgoingPaymentRequest, IncomingPayment,
     ListIncomingPaymentsResponse, ListOutgoingPaymentsResponse, OutgoingPayment, PaymentMethod,
-    PaymentMethodType,
+    PaymentMethodType, PublicIncomingPayment,
 };
 
 pub use op_types::resource::{CreateQuoteRequest as QuoteRequest, Quote};

--- a/op-client/src/utils.rs
+++ b/op-client/src/utils.rs
@@ -1,8 +1,44 @@
-pub fn get_resource_server_url(wallet_address_url: &str) -> Result<String, url::ParseError> {
-    let url = url::Url::parse(wallet_address_url)?;
-    Ok(format!(
-        "{}://{}",
-        url.scheme(),
-        url.host_str().ok_or(url::ParseError::EmptyHost)?
-    ))
+use crate::OpClientError;
+use crate::Result;
+use url::Url;
+
+pub fn get_resource_server_url(wallet_address_url: &str) -> Result<String> {
+    let url = Url::parse(wallet_address_url).map_err(|e| OpClientError::Url(e))?;
+
+    let path_segments: Vec<&str> = url
+        .path_segments()
+        .map(|segments| segments.collect())
+        .unwrap_or_default();
+
+    // Remove the last segment (wallet address) to get the resource server URL
+    let resource_server_path = if path_segments.len() > 1 {
+        path_segments[..path_segments.len() - 1].join("/")
+    } else {
+        String::new()
+    };
+
+    let mut resource_url = url;
+
+    if resource_server_path.is_empty() {
+        resource_url.set_path("/");
+    } else {
+        resource_url.set_path(&format!("/{}", resource_server_path));
+    }
+
+    Ok(resource_url.to_string())
+}
+
+pub fn join_url_paths(base_url: &str, path: &str) -> Result<String> {
+    let mut url = Url::parse(base_url).map_err(|e| OpClientError::Url(e))?;
+
+    if path.is_empty() {
+        return Ok(url.to_string());
+    }
+
+    if !url.path().ends_with('/') {
+        url.set_path(&format!("{}/", url.path()));
+    }
+
+    let joined_url = url.join(path).map_err(|e| OpClientError::Url(e))?;
+    Ok(joined_url.to_string())
 }

--- a/op-client/tests/integration/grant.rs
+++ b/op-client/tests/integration/grant.rs
@@ -6,7 +6,7 @@ use op_client::{
 
 #[tokio::test]
 async fn test_grant_flows() {
-    let mut test_setup = TestSetup::new().await.expect("Failed to create test setup");
+    let test_setup = TestSetup::new().await.expect("Failed to create test setup");
 
     let wallet_address = test_setup
         .auth_client
@@ -56,12 +56,10 @@ async fn test_grant_flows() {
         }
     };
 
-    test_setup.auth_client.access_token = Some(continue_.access_token.value);
-
     test_setup
         .auth_client
         .grant()
-        .cancel(&continue_.uri)
+        .cancel(&continue_.uri, Some(&continue_.access_token.value))
         .await
         .expect("Failed to cancel grant");
 }

--- a/op-client/tests/integration/token.rs
+++ b/op-client/tests/integration/token.rs
@@ -46,12 +46,11 @@ async fn test_token_flows() {
     let mut test_setup = TestSetup::new().await.expect("Failed to create test setup");
 
     let initial_token = get_access_token(&mut test_setup).await;
-    test_setup.auth_client.access_token = Some(initial_token.value.clone());
 
     let rotated_token_response = test_setup
         .auth_client
         .token()
-        .rotate(&initial_token.manage)
+        .rotate(&initial_token.manage, Some(&initial_token.value))
         .await
         .expect("Failed to rotate token");
 
@@ -60,12 +59,10 @@ async fn test_token_flows() {
     assert!(!rotated_token.manage.is_empty());
     assert_ne!(rotated_token.value, initial_token.value);
 
-    test_setup.auth_client.access_token = Some(rotated_token.value);
-
     test_setup
         .auth_client
         .token()
-        .revoke(&rotated_token.manage)
+        .revoke(&rotated_token.manage, Some(&rotated_token.value))
         .await
         .expect("Failed to revoke token");
 }

--- a/op-types/src/auth.rs
+++ b/op-types/src/auth.rs
@@ -94,7 +94,7 @@ pub struct AccessTokenRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InteractRequest {
     pub start: Vec<String>,
-    pub finish: InteractFinish,
+    pub finish: Option<InteractFinish>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/op-types/src/common.rs
+++ b/op-types/src/common.rs
@@ -1,19 +1,11 @@
-use once_cell::sync::Lazy;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::fmt;
-use std::str::FromStr;
-
-// Matches R[n]/P... format where [n] is optional number
-static INTERVAL_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^R\d*/P|^R/P").unwrap());
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Amount {
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    pub value: u64,
+    pub value: String,
     pub asset_code: String,
     pub asset_scale: u8,
 }
@@ -23,62 +15,6 @@ pub struct Receiver(pub String);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WalletAddressUri(pub String);
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ISO8601Format(String);
-
-impl FromStr for ISO8601Format {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if INTERVAL_REGEX.is_match(s) {
-            Ok(Self(s.to_string()))
-        } else {
-            Err("Invalid ISO8601 repeating interval format. Must start with R[n]/P".to_string())
-        }
-    }
-}
-
-impl fmt::Display for ISO8601Format {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Interval(#[serde_as(as = "serde_with::DisplayFromStr")] pub ISO8601Format);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_valid_intervals() {
-        let valid = vec![
-            "R/P1D",   // Repeat forever, daily
-            "R3/P1M",  // Repeat 3 times, monthly
-            "R5/PT1H", // Repeat 5 times, hourly
-        ];
-
-        for case in valid {
-            let interval: Interval = serde_json::from_value(json!(case)).unwrap();
-            assert_eq!(interval.0.0, case);
-        }
-    }
-
-    #[test]
-    fn test_invalid_intervals() {
-        let invalid = vec![
-            "P1D",     // Missing R prefix
-            "R1D",     // Missing /P
-            "invalid", // Invalid format
-            "",        // Empty string
-        ];
-
-        for case in invalid {
-            assert!(serde_json::from_value::<Interval>(json!(case)).is_err());
-        }
-    }
-}
+pub struct Interval(String);

--- a/open-payments-snippets-rust/src/grant/cancel.rs
+++ b/open-payments-snippets-rust/src/grant/cancel.rs
@@ -8,14 +8,15 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("CONTINUE_ACCESS_TOKEN")?;
     let continue_uri = get_env_var("CONTINUE_URI")?;
 
-    client.access_token = Some(gnap_token);
-
-    client.grant().cancel(&continue_uri).await?;
+    client
+        .grant()
+        .cancel(&continue_uri, Some(&gnap_token))
+        .await?;
 
     println!("Grant cancelled successfully");
     Ok(())

--- a/open-payments-snippets-rust/src/grant/continuation.rs
+++ b/open-payments-snippets-rust/src/grant/continuation.rs
@@ -9,17 +9,15 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("CONTINUE_ACCESS_TOKEN")?;
     let continue_uri = get_env_var("CONTINUE_URI")?;
     let interact_ref = get_env_var("INTERACT_REF")?;
 
-    client.access_token = Some(gnap_token);
-
     let response = client
         .grant()
-        .continue_grant(&continue_uri, &interact_ref)
+        .continue_grant(&continue_uri, &interact_ref, Some(&gnap_token))
         .await?;
 
     match response {

--- a/open-payments-snippets-rust/src/grant/outgoing_payment.rs
+++ b/open-payments-snippets-rust/src/grant/outgoing_payment.rs
@@ -18,17 +18,15 @@ async fn main() -> op_client::Result<()> {
     load_env()?;
 
     // Authenticated client can be also used for unauthenticated resources
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let quote_url = get_env_var("QUOTE_URL")?;
     let gnap_token = get_env_var("QUOTE_ACCESS_TOKEN")?;
 
-    client.access_token = Some(gnap_token);
-
     let wallet_address = client.wallet_address().get(&wallet_address_url).await?;
 
-    let quote = client.quotes().get(&quote_url).await?;
+    let quote = client.quotes().get(&quote_url, Some(&gnap_token)).await?;
 
     let wallet_id = &wallet_address.id;
     let grant_request = GrantRequest {
@@ -52,11 +50,11 @@ async fn main() -> op_client::Result<()> {
         client: wallet_id.to_string(),
         interact: Some(InteractRequest {
             start: vec!["redirect".to_string()],
-            finish: InteractFinish {
+            finish: Some(InteractFinish {
                 method: "redirect".to_string(),
                 uri: "http://localhost".to_string(),
                 nonce: Uuid::new_v4().to_string(),
-            },
+            }),
         }),
     };
 

--- a/open-payments-snippets-rust/src/incoming_payment/complete.rs
+++ b/open-payments-snippets-rust/src/incoming_payment/complete.rs
@@ -11,12 +11,11 @@ async fn main() -> op_client::Result<()> {
     let gnap_token = get_env_var("INCOMING_PAYMENT_ACCESS_TOKEN")?;
     let incoming_payment_url = get_env_var("INCOMING_PAYMENT_URL")?;
 
-    let mut client = create_authenticated_client()?;
-    client.access_token = Some(gnap_token);
+    let client = create_authenticated_client()?;
 
     let payment = client
         .incoming_payments()
-        .complete(&incoming_payment_url)
+        .complete(&incoming_payment_url, Some(&gnap_token))
         .await?;
 
     println!("Completed incoming payment: {:#?}", payment);

--- a/open-payments-snippets-rust/src/incoming_payment/create.rs
+++ b/open-payments-snippets-rust/src/incoming_payment/create.rs
@@ -12,10 +12,9 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env().map_err(|e| OpClientError::Other(e.to_string()))?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("INCOMING_PAYMENT_ACCESS_TOKEN")?;
-    client.access_token = Some(gnap_token);
 
     let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let resource_server_url = get_resource_server_url(&wallet_address_url)?;
@@ -28,7 +27,7 @@ async fn main() -> op_client::Result<()> {
     let request = CreateIncomingPaymentRequest {
         wallet_address: wallet_address_url,
         incoming_amount: Some(Amount {
-            value: 1000,
+            value: "1000".to_string(),
             asset_code: "EUR".to_string(),
             asset_scale: 2u8,
         }),
@@ -43,7 +42,7 @@ async fn main() -> op_client::Result<()> {
 
     let payment = client
         .incoming_payments()
-        .create(&resource_server_url, &request)
+        .create(&resource_server_url, &request, Some(&gnap_token))
         .await?;
 
     println!("Created incoming payment: {:#?}", payment);

--- a/open-payments-snippets-rust/src/incoming_payment/get.rs
+++ b/open-payments-snippets-rust/src/incoming_payment/get.rs
@@ -8,16 +8,14 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("INCOMING_PAYMENT_ACCESS_TOKEN")?;
     let incoming_payment_url = get_env_var("INCOMING_PAYMENT_URL")?;
 
-    client.access_token = Some(gnap_token);
-
     let payment = client
         .incoming_payments()
-        .get(&incoming_payment_url)
+        .get(&incoming_payment_url, Some(&gnap_token))
         .await?;
 
     println!("Incoming payment: {:#?}", payment);

--- a/open-payments-snippets-rust/src/incoming_payment/list.rs
+++ b/open-payments-snippets-rust/src/incoming_payment/list.rs
@@ -9,10 +9,9 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("INCOMING_PAYMENT_ACCESS_TOKEN")?;
-    client.access_token = Some(gnap_token);
 
     let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let resource_server_url = get_resource_server_url(&wallet_address_url)?;
@@ -24,6 +23,7 @@ async fn main() -> op_client::Result<()> {
             None,
             Some(10),
             None,
+            Some(&gnap_token),
         )
         .await?;
 
@@ -40,6 +40,7 @@ async fn main() -> op_client::Result<()> {
                     Some(&end_cursor),
                     Some(10),
                     None,
+                    Some(&gnap_token),
                 )
                 .await?;
             println!("Next page of incoming payments: {:#?}", next_page.result);

--- a/open-payments-snippets-rust/src/outgoing_payment/create.rs
+++ b/open-payments-snippets-rust/src/outgoing_payment/create.rs
@@ -9,14 +9,12 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("OUTGOING_PAYMENT_ACCESS_TOKEN")?;
     let quote_url = get_env_var("QUOTE_URL")?;
     let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let resource_server_url = get_resource_server_url(&wallet_address_url)?;
-
-    client.access_token = Some(gnap_token);
 
     let request = OutgoingPaymentRequest::FromQuote {
         wallet_address: wallet_address_url,
@@ -31,7 +29,7 @@ async fn main() -> op_client::Result<()> {
 
     let payment = client
         .outgoing_payments()
-        .create(&resource_server_url, &request)
+        .create(&resource_server_url, &request, Some(&gnap_token))
         .await?;
 
     println!("Created outgoing payment: {:#?}", payment);

--- a/open-payments-snippets-rust/src/outgoing_payment/get.rs
+++ b/open-payments-snippets-rust/src/outgoing_payment/get.rs
@@ -8,15 +8,14 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("OUTGOING_PAYMENT_ACCESS_TOKEN")?;
     let outgoing_payment_url = get_env_var("OUTGOING_PAYMENT_URL")?;
-    client.access_token = Some(gnap_token);
 
     let payment = client
         .outgoing_payments()
-        .get(&outgoing_payment_url)
+        .get(&outgoing_payment_url, Some(&gnap_token))
         .await?;
 
     println!("Outgoing payment: {:#?}", payment);

--- a/open-payments-snippets-rust/src/outgoing_payment/list.rs
+++ b/open-payments-snippets-rust/src/outgoing_payment/list.rs
@@ -9,10 +9,9 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("OUTGOING_PAYMENT_ACCESS_TOKEN")?;
-    client.access_token = Some(gnap_token);
 
     let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let resource_server_url = get_resource_server_url(&wallet_address_url)?;
@@ -25,6 +24,7 @@ async fn main() -> op_client::Result<()> {
             None,
             Some(10),
             None,
+            Some(&gnap_token),
         )
         .await?;
 
@@ -41,6 +41,7 @@ async fn main() -> op_client::Result<()> {
                     Some(&end_cursor),
                     Some(10),
                     None,
+                    Some(&gnap_token),
                 )
                 .await?;
             println!("Next page of outgoing payments: {:#?}", next_page.result);

--- a/open-payments-snippets-rust/src/quote/create.rs
+++ b/open-payments-snippets-rust/src/quote/create.rs
@@ -10,14 +10,12 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("QUOTE_ACCESS_TOKEN")?;
     let incoming_payment_url = get_env_var("INCOMING_PAYMENT_URL")?;
     let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let resource_server_url = get_resource_server_url(&wallet_address_url)?;
-
-    client.access_token = Some(gnap_token);
 
     let request = CreateQuoteRequest::NoAmountQuote {
         wallet_address: wallet_address_url,
@@ -32,7 +30,7 @@ async fn main() -> op_client::Result<()> {
 
     let quote = client
         .quotes()
-        .create(&resource_server_url, &request)
+        .create(&resource_server_url, &request, Some(&gnap_token))
         .await?;
 
     println!("Created quote: {:#?}", quote);

--- a/open-payments-snippets-rust/src/quote/create_with_debit_amount.rs
+++ b/open-payments-snippets-rust/src/quote/create_with_debit_amount.rs
@@ -10,21 +10,19 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("QUOTE_ACCESS_TOKEN")?;
     let incoming_payment_url = get_env_var("INCOMING_PAYMENT_URL")?;
     let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let resource_server_url = get_resource_server_url(&wallet_address_url)?;
 
-    client.access_token = Some(gnap_token);
-
     let request = CreateQuoteRequest::FixedSendAmountQuote {
         wallet_address: wallet_address_url,
         receiver: Receiver(incoming_payment_url),
         method: PaymentMethodType::Ilp,
         debit_amount: Amount {
-            value: 1000,
+            value: "1000".to_string(),
             asset_code: "EUR".to_string(),
             asset_scale: 2u8,
         },
@@ -37,7 +35,7 @@ async fn main() -> op_client::Result<()> {
 
     let quote = client
         .quotes()
-        .create(&resource_server_url, &request)
+        .create(&resource_server_url, &request, Some(&gnap_token))
         .await?;
 
     println!("Created quote: {:#?}", quote);

--- a/open-payments-snippets-rust/src/quote/create_with_receive_amount.rs
+++ b/open-payments-snippets-rust/src/quote/create_with_receive_amount.rs
@@ -10,21 +10,19 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("QUOTE_ACCESS_TOKEN")?;
     let incoming_payment_url = get_env_var("INCOMING_PAYMENT_URL")?;
     let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let resource_server_url = get_resource_server_url(&wallet_address_url)?;
 
-    client.access_token = Some(gnap_token);
-
     let request = CreateQuoteRequest::FixedReceiveAmountQuote {
         wallet_address: wallet_address_url,
         receiver: Receiver(incoming_payment_url),
         method: PaymentMethodType::Ilp,
         receive_amount: Amount {
-            value: 1000,
+            value: "1000".to_string(),
             asset_code: "EUR".to_string(),
             asset_scale: 2u8,
         },
@@ -37,7 +35,7 @@ async fn main() -> op_client::Result<()> {
 
     let quote = client
         .quotes()
-        .create(&resource_server_url, &request)
+        .create(&resource_server_url, &request, Some(&gnap_token))
         .await?;
 
     println!("Created quote: {:#?}", quote);

--- a/open-payments-snippets-rust/src/quote/get.rs
+++ b/open-payments-snippets-rust/src/quote/get.rs
@@ -8,14 +8,12 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("QUOTE_ACCESS_TOKEN")?;
     let quote_url = get_env_var("QUOTE_URL")?;
 
-    client.access_token = Some(gnap_token);
-
-    let quote = client.quotes().get(&quote_url).await?;
+    let quote = client.quotes().get(&quote_url, Some(&gnap_token)).await?;
 
     println!("Quote: {:#?}", quote);
     Ok(())

--- a/open-payments-snippets-rust/src/token/revoke.rs
+++ b/open-payments-snippets-rust/src/token/revoke.rs
@@ -8,14 +8,15 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("ACCESS_TOKEN")?;
     let token_manage_url = get_env_var("TOKEN_MANAGE_URL")?;
 
-    client.access_token = Some(gnap_token);
-
-    client.token().revoke(&token_manage_url).await?;
+    client
+        .token()
+        .revoke(&token_manage_url, Some(&gnap_token))
+        .await?;
 
     println!("Access token revoked successfully");
     Ok(())

--- a/open-payments-snippets-rust/src/token/rotate.rs
+++ b/open-payments-snippets-rust/src/token/rotate.rs
@@ -8,14 +8,15 @@ async fn main() -> op_client::Result<()> {
     init_logging();
     load_env()?;
 
-    let mut client = create_authenticated_client()?;
+    let client = create_authenticated_client()?;
 
     let gnap_token = get_env_var("ACCESS_TOKEN")?;
     let token_manage_url = get_env_var("TOKEN_MANAGE_URL")?;
 
-    client.access_token = Some(gnap_token);
-
-    let response = client.token().rotate(&token_manage_url).await?;
+    let response = client
+        .token()
+        .rotate(&token_manage_url, Some(&gnap_token))
+        .await?;
 
     println!("Rotated access token: {:#?}", response.access_token);
     Ok(())


### PR DESCRIPTION
This PR introduces the following changes:

- Access token is passed as parameter to each client call such that any potential for race conditions is eliminated
- Urls are parsed using `url` crate
- Added tests for `load_or_generate_key` function from `http-signatures-utils` crate
- Added public incoming payment as unauthenticated resource
- Removed custom serialization/deserialization for `Amount` and `Interval` structs to achieve feature parity with other SDKs i.e. not checking if amount is a positive value or interval is valid.