### PR TITLE
fix: update doc comments to reflect correct flows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-payments"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Interledger <tech@interledger.org>"]
 description = "Open Payments Rust SDK library with types, HTTP client and signature utilities"
@@ -9,7 +9,6 @@ repository = "https://github.com/interledger/open-payments-rust"
 readme = "README.md"
 keywords = ["open-payments", "interledger", "payments", "http-signatures", "gnap"]
 categories = ["api-bindings", "web-programming", "asynchronous"]
-documentation = "https://docs.rs/open-payments"
 homepage = "https://github.com/interledger/open-payments-rust"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Payments Rust
+# Open Payments
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/interledger/open-payments/main/docs/public/img/logo.svg" width="700" alt="Open Payments">

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -28,6 +28,7 @@
 //!
 //! ```rust,no_run
 //! use open_payments::client::{AuthenticatedClient, ClientConfig, AuthenticatedResources, UnauthenticatedResources};
+//! use open_payments::types::{GrantRequest, AccessTokenRequest, AccessItem, IncomingPaymentAction, CreateIncomingPaymentRequest};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -45,10 +46,24 @@
 //!     // Example of how to use the client (would require actual server)
 //!     let wallet_address = client.wallet_address().get("https://rafiki.money/alice").await?;
 //!
+//!     // Example of how to request a grant
+//!     let grant_request = GrantRequest {
+//!         access_token: AccessTokenRequest {
+//!             access: vec![AccessItem::IncomingPayment {
+//!                 actions: vec![IncomingPaymentAction::Create, IncomingPaymentAction::Read],
+//!                 identifier: None,
+//!             }],
+//!         },
+//!         client: "https://rafiki.money/alice".to_string(),
+//!         interact: None,
+//!     };
+//! 
+//!     let access_token = client.grant().request(&wallet_address.auth_server, &grant_request).await?;
+//!
 //!     // Example of creating a payment request
 //!     let resource_server = "https://ilp.rafiki.money";
 //!     let access_token = "your-access-token";
-//!     let payment_request = open_payments::types::resource::CreateIncomingPaymentRequest {
+//!     let payment_request = CreateIncomingPaymentRequest {
 //!         wallet_address: wallet_address.id,
 //!         incoming_amount: None,
 //!         expires_at: None,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -57,7 +57,7 @@
 //!         client: "https://rafiki.money/alice".to_string(),
 //!         interact: None,
 //!     };
-//! 
+//!
 //!     let access_token = client.grant().request(&wallet_address.auth_server, &grant_request).await?;
 //!
 //!     // Example of creating a payment request

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -229,7 +229,7 @@ impl AuthenticatedRequest<'_> {
     ///
     /// This method generates `Content-Length` and `Content-Digest` headers for
     /// requests with body content. The content digest uses SHA-512 hashing
-    /// as required by the Open Payments protocol.
+    /// as required by the Open Payments specification.
     ///
     /// ## Arguments
     ///

--- a/src/http_signature/mod.rs
+++ b/src/http_signature/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides utilities for creating and validating HTTP message signatures
 //! according to the [HTTP Message Signatures](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures) specification.
-//! It supports Ed25519 signing and is designed for use with the Open Payments protocol.
+//! It supports Ed25519 signing and is designed for use with the Open Payments specification.
 //!
 //! ## Features
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Open Payments Rust Client
 //!
-//! A Rust client library for the Open Payments protocol, providing types and HTTP signatures utilities for building Open Payments applications.
+//! A Rust client library for the Open Payments specification, providing types and HTTP signatures utilities for building Open Payments applications.
 //!
 //! ## Features
 //!

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,6 @@
 //! # Open Payments Types
 //!
-//! This module contains all the type definitions for the Open Payments protocol.
+//! This module contains all the type definitions for the Open Payments specifications.
 //! These types represent the data structures used in API requests and responses,
 //! as well as the core concepts of the Open Payments ecosystem.
 //!
@@ -23,22 +23,24 @@
 //! ### Common Types
 //!
 //! - [`Amount`] - Amounts of a specific currency and scale
-//! - [`PageInfo`] - Pagination information
-//! - [`PaginatedResponse`] - Generic paginated response wrapper
+//! - [`Receiver`] - Receiver of a payment e.g. incoming payment
+//! - [`WalletAddressUri`] - Wallet address descriptor
+//! - [`Interval`] - ISO 8601 defined interval
 //!
 //! ## Example Usage
 //!
 //! ```rust
 //! use open_payments::types::{
 //!     Amount, GrantRequest, AccessTokenRequest, AccessItem, QuoteAction,
-//!     CreateIncomingPaymentRequest, WalletAddress
+//!     CreateIncomingPaymentRequest, WalletAddress, IncomingPaymentAction
 //! };
 //!
-//! // Create a grant request for quote access
+//! // Create a grant request for incoming payment
 //! let grant_request = GrantRequest {
 //!     access_token: AccessTokenRequest {
-//!         access: vec![AccessItem::Quote {
-//!             actions: vec![QuoteAction::Create, QuoteAction::Read],
+//!         access: vec![AccessItem::IncomingPayment {
+//!             actions: vec![IncomingPaymentAction::Create, IncomingPaymentAction::Read],
+//!             identifier: None,
 //!         }],
 //!     },
 //!     client: "https://rafiki.money/alice".to_string(),


### PR DESCRIPTION
## Changes proposed in this pull request

Update doc comments to reflect correct flows
Remove `docs.rs` link from Cargo.toml as it will be added by default.

## Context