### PR TITLE
fix: update incoming and outgoing payments response types w/ missing fields

### DIFF
--- a/src/client/core.rs
+++ b/src/client/core.rs
@@ -78,13 +78,13 @@ impl AuthenticatedOpenPaymentsClient {
         let http_client = ReqwestClient::new();
 
         let signing_key = load_or_generate_key(&config.private_key_path).map_err(|e| {
-            OpClientError::Signature(format!("Failed to load or generate signing key: {}", e))
+            OpClientError::Signature(format!("Failed to load or generate signing key: {e}"))
         })?;
 
         if let Some(ref jwks_path) = config.jwks_path {
             let jwks_json = Jwk::generate_jwks_json(&signing_key, &config.key_id);
             Jwk::save_jwks(&jwks_json, jwks_path).map_err(|e| {
-                OpClientError::Signature(format!("Failed to save JWK to file: {}", e))
+                OpClientError::Signature(format!("Failed to save JWK to file: {e}"))
             })?;
         }
 

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -125,7 +125,7 @@ impl From<reqwest::Error> for OpClientError {
     /// This implementation allows the client to automatically convert reqwest errors
     /// into the unified error type, providing consistent error handling across the library.
     fn from(err: reqwest::Error) -> Self {
-        OpClientError::Http(format!("{}", err))
+        OpClientError::Http(format!("{err}"))
     }
 }
 

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -137,10 +137,7 @@ impl AuthenticatedRequest<'_> {
             req.headers_mut().insert(
                 "Authorization",
                 format!("GNAP {token}").parse().map_err(|e| {
-                    OpClientError::HeaderParse(format!(
-                        "Failed to parse authorization header: {}",
-                        e
-                    ))
+                    OpClientError::HeaderParse(format!("Failed to parse authorization header: {e}"))
                 })?,
             );
         }

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -136,7 +136,7 @@ impl AuthenticatedRequest<'_> {
         if let Some(token) = access_token {
             req.headers_mut().insert(
                 "Authorization",
-                format!("GNAP {}", token).parse().map_err(|e| {
+                format!("GNAP {token}").parse().map_err(|e| {
                     OpClientError::HeaderParse(format!(
                         "Failed to parse authorization header: {}",
                         e
@@ -149,13 +149,13 @@ impl AuthenticatedRequest<'_> {
             req.headers_mut().insert(
                 "Content-Length",
                 content_length.to_string().parse().map_err(|e| {
-                    OpClientError::HeaderParse(format!("Failed to parse content length: {}", e))
+                    OpClientError::HeaderParse(format!("Failed to parse content length: {e}"))
                 })?,
             );
             req.headers_mut().insert(
                 "Content-Digest",
                 content_digest.parse().map_err(|e| {
-                    OpClientError::HeaderParse(format!("Failed to parse content digest: {}", e))
+                    OpClientError::HeaderParse(format!("Failed to parse content digest: {e}"))
                 })?,
             );
         }
@@ -165,13 +165,13 @@ impl AuthenticatedRequest<'_> {
         req.headers_mut().insert(
             "Signature",
             signature.parse().map_err(|e| {
-                OpClientError::HeaderParse(format!("Failed to parse signature header: {}", e))
+                OpClientError::HeaderParse(format!("Failed to parse signature header: {e}"))
             })?,
         );
         req.headers_mut().insert(
             "Signature-Input",
             signature_input.parse().map_err(|e| {
-                OpClientError::HeaderParse(format!("Failed to parse signature input header: {}", e))
+                OpClientError::HeaderParse(format!("Failed to parse signature input header: {e}"))
             })?,
         );
 
@@ -196,20 +196,18 @@ impl AuthenticatedRequest<'_> {
         // Convert to http::Request for signing
         let mut http_req = Request::new(self.body.clone());
         *http_req.method_mut() = HttpMethod::from_bytes(req.method().as_str().as_bytes())
-            .map_err(|e| OpClientError::HeaderParse(format!("Converting HTTP method: {}", e)))?;
+            .map_err(|e| OpClientError::HeaderParse(format!("Converting HTTP method: {e}")))?;
         *http_req.uri_mut() = req
             .url()
             .as_str()
             .parse()
-            .map_err(|e| OpClientError::HeaderParse(format!("Converting URL to URI: {}", e)))?;
+            .map_err(|e| OpClientError::HeaderParse(format!("Converting URL to URI: {e}")))?;
 
         for (key, value) in req.headers() {
-            let header_name = HeaderName::from_bytes(key.as_str().as_bytes()).map_err(|e| {
-                OpClientError::HeaderParse(format!("Converting header name: {}", e))
-            })?;
-            let header_value = HeaderValue::from_bytes(value.as_bytes()).map_err(|e| {
-                OpClientError::HeaderParse(format!("Converting header value: {}", e))
-            })?;
+            let header_name = HeaderName::from_bytes(key.as_str().as_bytes())
+                .map_err(|e| OpClientError::HeaderParse(format!("Converting header name: {e}")))?;
+            let header_value = HeaderValue::from_bytes(value.as_bytes())
+                .map_err(|e| OpClientError::HeaderParse(format!("Converting header value: {e}")))?;
             http_req.headers_mut().insert(header_name, header_value);
         }
 
@@ -246,7 +244,7 @@ impl AuthenticatedRequest<'_> {
                 let mut hasher = Sha512::new();
                 hasher.update(body.as_bytes());
                 let digest = general_purpose::STANDARD.encode(hasher.finalize());
-                let content_digest = format!("sha-512=:{}:", digest);
+                let content_digest = format!("sha-512=:{digest}:");
 
                 Some((content_length, content_digest))
             }

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -48,7 +48,7 @@ pub fn get_resource_server_url(wallet_address_url: &str) -> Result<String> {
     if resource_server_path.is_empty() {
         resource_url.set_path("/");
     } else {
-        resource_url.set_path(&format!("/{}", resource_server_path));
+        resource_url.set_path(&format!("/{resource_server_path}"));
     }
 
     Ok(resource_url.to_string())

--- a/src/http_signature/examples/generate_signature.rs
+++ b/src/http_signature/examples/generate_signature.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), HttpSignatureError> {
     request.headers_mut().insert(
         "Content-Type",
         "application/json".parse().map_err(|e| {
-            HttpSignatureError::Other(format!("Failed to parse content type: {}", e))
+            HttpSignatureError::Other(format!("Failed to parse content type: {e}"))
         })?,
     );
 

--- a/src/http_signature/examples/generate_signature.rs
+++ b/src/http_signature/examples/generate_signature.rs
@@ -13,9 +13,9 @@ fn main() -> Result<(), HttpSignatureError> {
     *request.uri_mut() = Uri::from_static("http://example.com/");
     request.headers_mut().insert(
         "Content-Type",
-        "application/json".parse().map_err(|e| {
-            HttpSignatureError::Other(format!("Failed to parse content type: {e}"))
-        })?,
+        "application/json"
+            .parse()
+            .map_err(|e| HttpSignatureError::Other(format!("Failed to parse content type: {e}")))?,
     );
 
     // Generate a signing key

--- a/src/http_signature/signatures.rs
+++ b/src/http_signature/signatures.rs
@@ -64,7 +64,7 @@ fn create_signature_base_string(
                 .unwrap_or(""),
             _ => "",
         };
-        parts.push(format!("\"{}\": {}", component, value));
+        parts.push(format!("\"{component}\": {value}"));
     }
 
     let sig_params = format!(
@@ -73,7 +73,7 @@ fn create_signature_base_string(
         created,
         keyid
     );
-    parts.push(format!("\"@signature-params\": {}", sig_params));
+    parts.push(format!("\"@signature-params\": {sig_params}"));
 
     parts.join("\n")
 }

--- a/src/http_signature/validation.rs
+++ b/src/http_signature/validation.rs
@@ -57,7 +57,7 @@ fn create_signature_base_string(
                 .unwrap_or(""),
             _ => "",
         };
-        parts.push(format!("\"{}\": {}", component, value));
+        parts.push(format!("\"{component}\": {value}"));
     }
 
     let sig_params = format!(
@@ -66,7 +66,7 @@ fn create_signature_base_string(
         created,
         keyid
     );
-    parts.push(format!("\"@signature-params\": {}", sig_params));
+    parts.push(format!("\"@signature-params\": {sig_params}"));
 
     parts.join("\n")
 }

--- a/src/snippets/grant/outgoing_payment.rs
+++ b/src/snippets/grant/outgoing_payment.rs
@@ -77,8 +77,8 @@ async fn main() -> open_payments::client::Result<()> {
             interact,
             continue_,
         } => {
-            println!("Received interact: {:#?}", interact);
-            println!("Received continue: {:#?}", continue_);
+            println!("Received interact: {interact:#?}");
+            println!("Received continue: {continue_:#?}");
         }
     }
 

--- a/src/snippets/incoming_payment/complete.rs
+++ b/src/snippets/incoming_payment/complete.rs
@@ -15,6 +15,6 @@ async fn main() -> open_payments::client::Result<()> {
         .complete(&incoming_payment_url, Some(&gnap_token))
         .await?;
 
-    println!("Completed incoming payment: {:#?}", payment);
+    println!("Completed incoming payment: {payment:#?}");
     Ok(())
 }

--- a/src/snippets/incoming_payment/create.rs
+++ b/src/snippets/incoming_payment/create.rs
@@ -42,6 +42,6 @@ async fn main() -> open_payments::client::Result<()> {
         .create(&resource_server_url, &request, Some(&gnap_token))
         .await?;
 
-    println!("Created incoming payment: {:#?}", payment);
+    println!("Created incoming payment: {payment:#?}");
     Ok(())
 }

--- a/src/snippets/incoming_payment/get.rs
+++ b/src/snippets/incoming_payment/get.rs
@@ -15,6 +15,6 @@ async fn main() -> open_payments::client::Result<()> {
         .get(&incoming_payment_url, Some(&gnap_token))
         .await?;
 
-    println!("Incoming payment: {:#?}", payment);
+    println!("Incoming payment: {payment:#?}");
     Ok(())
 }

--- a/src/snippets/outgoing_payment/create.rs
+++ b/src/snippets/outgoing_payment/create.rs
@@ -30,6 +30,6 @@ async fn main() -> open_payments::client::Result<()> {
         .create(&resource_server_url, &request, Some(&gnap_token))
         .await?;
 
-    println!("Created outgoing payment: {:#?}", payment);
+    println!("Created outgoing payment: {payment:#?}");
     Ok(())
 }

--- a/src/snippets/outgoing_payment/get.rs
+++ b/src/snippets/outgoing_payment/get.rs
@@ -15,6 +15,6 @@ async fn main() -> open_payments::client::Result<()> {
         .get(&outgoing_payment_url, Some(&gnap_token))
         .await?;
 
-    println!("Outgoing payment: {:#?}", payment);
+    println!("Outgoing payment: {payment:#?}");
     Ok(())
 }

--- a/src/snippets/quote/create.rs
+++ b/src/snippets/quote/create.rs
@@ -30,6 +30,6 @@ async fn main() -> open_payments::client::Result<()> {
         .create(&resource_server_url, &request, Some(&gnap_token))
         .await?;
 
-    println!("Created quote: {:#?}", quote);
+    println!("Created quote: {quote:#?}");
     Ok(())
 }

--- a/src/snippets/quote/create_with_debit_amount.rs
+++ b/src/snippets/quote/create_with_debit_amount.rs
@@ -35,6 +35,6 @@ async fn main() -> open_payments::client::Result<()> {
         .create(&resource_server_url, &request, Some(&gnap_token))
         .await?;
 
-    println!("Created quote: {:#?}", quote);
+    println!("Created quote: {quote:#?}");
     Ok(())
 }

--- a/src/snippets/quote/create_with_receive_amount.rs
+++ b/src/snippets/quote/create_with_receive_amount.rs
@@ -35,6 +35,6 @@ async fn main() -> open_payments::client::Result<()> {
         .create(&resource_server_url, &request, Some(&gnap_token))
         .await?;
 
-    println!("Created quote: {:#?}", quote);
+    println!("Created quote: {quote:#?}");
     Ok(())
 }

--- a/src/snippets/quote/get.rs
+++ b/src/snippets/quote/get.rs
@@ -12,6 +12,6 @@ async fn main() -> open_payments::client::Result<()> {
 
     let quote = client.quotes().get(&quote_url, Some(&gnap_token)).await?;
 
-    println!("Quote: {:#?}", quote);
+    println!("Quote: {quote:#?}");
     Ok(())
 }

--- a/src/snippets/utils/mod.rs
+++ b/src/snippets/utils/mod.rs
@@ -11,7 +11,7 @@ pub fn load_env() -> Result<()> {
 }
 
 pub fn get_env_var(key: &str) -> Result<String> {
-    env::var(key).map_err(|_| OpClientError::Other(format!("{} environment variable not set", key)))
+    env::var(key).map_err(|_| OpClientError::Other(format!("{key} environment variable not set")))
 }
 
 pub fn create_authenticated_client() -> Result<AuthenticatedClient> {

--- a/src/snippets/wallet_address/get.rs
+++ b/src/snippets/wallet_address/get.rs
@@ -11,6 +11,6 @@ async fn main() -> open_payments::client::Result<()> {
 
     let wallet_address = client.wallet_address().get(&wallet_address_url).await?;
 
-    println!("Retrieved wallet address: {:#?}", wallet_address);
+    println!("Retrieved wallet address: {wallet_address:#?}");
     Ok(())
 }

--- a/src/snippets/wallet_address/get_keys.rs
+++ b/src/snippets/wallet_address/get_keys.rs
@@ -13,7 +13,7 @@ async fn main() -> open_payments::client::Result<()> {
 
     let keys = client.wallet_address().get_keys(&wallet_address).await?;
 
-    println!("Retrieved wallet address: {:#?}", wallet_address);
-    println!("Retrieved keys: {:#?}", keys);
+    println!("Retrieved wallet address: {wallet_address:#?}");
+    println!("Retrieved keys: {keys:#?}");
     Ok(())
 }

--- a/src/types/resource.rs
+++ b/src/types/resource.rs
@@ -18,6 +18,7 @@ pub struct IncomingPayment {
     pub metadata: Option<Value>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub methods: Option<Vec<PaymentMethod>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -71,6 +72,8 @@ pub struct OutgoingPayment {
     pub receive_amount: Amount,
     pub debit_amount: Amount,
     pub sent_amount: Amount,
+    pub grant_spent_debit_amount: Amount,
+    pub grant_spent_receive_amount: Amount,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
     pub created_at: DateTime<Utc>,


### PR DESCRIPTION
## Changes proposed in this pull request

This PR adds `methods` field to the `IncomingPayment` type as well as grant spent amount related fields on `OutgoingPayment` type

## Context

fixes #18 