### PR TITLE
fix: remove client field from GrantRequest type

### DIFF
--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 ///     key_id: "my-key-2024".to_string(),
 ///     private_key_path: PathBuf::from("keys/private.pem"),
 ///     jwks_path: Some(PathBuf::from("keys/jwks.json")),
+///     wallet_address_url: "https://rafiki.money/alice".into(),
 /// };
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -43,6 +43,11 @@ pub struct ClientConfig {
     ///
     /// Example: `Some(PathBuf::from("keys/jwks.json"))`
     pub jwks_path: Option<PathBuf>,
+
+    /// URL of the wallet address to use for the client.
+    ///
+    /// This is the URL of the wallet address that will be used to send and receive payments.
+    pub wallet_address_url: String,
 }
 
 impl Default for ClientConfig {
@@ -68,7 +73,8 @@ impl Default for ClientConfig {
         Self {
             key_id: "".into(),
             private_key_path: PathBuf::from("private.key"),
-            jwks_path: Some(PathBuf::from("jwks.json")),
+            jwks_path: None,
+            wallet_address_url: "".into(),
         }
     }
 }

--- a/src/client/core.rs
+++ b/src/client/core.rs
@@ -31,6 +31,7 @@ pub trait BaseClient {
 ///         private_key_path: "path/to/private-key.pem".into(),
 ///         key_id: "my-key-id".to_string(),
 ///         jwks_path: Some("path/to/jwks.json".into()),
+///         wallet_address_url: "https://rafiki.money/alice".into(),
 ///     };
 ///
 ///     // This would fail in a real scenario if the files don't exist

--- a/src/client/grant.rs
+++ b/src/client/grant.rs
@@ -10,7 +10,11 @@ pub(crate) async fn request_grant(
     auth_url: &str,
     grant: &GrantRequest,
 ) -> Result<GrantResponse> {
-    let body = serde_json::to_string(grant).map_err(OpClientError::Serde)?;
+    let grant_with_client = GrantRequest {
+        client: client.config.wallet_address_url.clone(),
+        ..grant.clone()
+    };
+    let body = serde_json::to_string(&grant_with_client).map_err(OpClientError::Serde)?;
 
     AuthenticatedRequest::new(client, Method::POST, auth_url.to_string())
         .with_body(body)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -37,6 +37,7 @@
 //!         private_key_path: "path/to/private-key.pem".into(),
 //!         key_id: "my-key-id".to_string(),
 //!         jwks_path: Some("path/to/jwks.json".into()),
+//!         wallet_address_url: "https://rafiki.money/alice".into(),
 //!     };
 //!
 //!     // This would fail in a real scenario if the files don't exist
@@ -47,16 +48,15 @@
 //!     let wallet_address = client.wallet_address().get("https://rafiki.money/alice").await?;
 //!
 //!     // Example of how to request a grant
-//!     let grant_request = GrantRequest {
-//!         access_token: AccessTokenRequest {
+//!     let grant_request = GrantRequest::new(
+//!         AccessTokenRequest {
 //!             access: vec![AccessItem::IncomingPayment {
 //!                 actions: vec![IncomingPaymentAction::Create, IncomingPaymentAction::Read],
 //!                 identifier: None,
 //!             }],
 //!         },
-//!         client: "https://rafiki.money/alice".to_string(),
-//!         interact: None,
-//!     };
+//!         None,
+//!     );
 //!
 //!     let access_token = client.grant().request(&wallet_address.auth_server, &grant_request).await?;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //!         private_key_path: "path/to/private-key.pem".into(),
 //!         key_id: "my-key-id".to_string(),
 //!         jwks_path: Some("path/to/jwks.json".into()),
+//!         wallet_address_url: "https://rafiki.money/alice".into(),
 //!     };
 //!
 //!     // This would fail in a real scenario if the files don't exist
@@ -63,6 +64,7 @@
 //!         private_key_path: "path/to/private-key.pem".into(),
 //!         key_id: "my-key-id".to_string(),
 //!         jwks_path: Some("path/to/jwks.json".into()),
+//!         wallet_address_url: "https://rafiki.money/alice".into(),
 //!     };
 //!     
 //!     // This would fail in a real scenario if the files don't exist

--- a/src/snippets/grant/incoming_payment.rs
+++ b/src/snippets/grant/incoming_payment.rs
@@ -15,8 +15,8 @@ async fn main() -> open_payments::client::Result<()> {
     let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let wallet_address = client.wallet_address().get(&wallet_address_url).await?;
 
-    let grant_request = GrantRequest {
-        access_token: AccessTokenRequest {
+    let grant_request = GrantRequest::new(
+        AccessTokenRequest {
             access: vec![AccessItem::IncomingPayment {
                 actions: vec![
                     IncomingPaymentAction::Create,
@@ -28,9 +28,8 @@ async fn main() -> open_payments::client::Result<()> {
                 identifier: None,
             }],
         },
-        client: wallet_address.id,
-        interact: None,
-    };
+        None,
+    );
 
     println!(
         "Grant request JSON: {}",

--- a/src/snippets/grant/outgoing_payment.rs
+++ b/src/snippets/grant/outgoing_payment.rs
@@ -26,8 +26,8 @@ async fn main() -> open_payments::client::Result<()> {
     let quote = client.quotes().get(&quote_url, Some(&gnap_token)).await?;
 
     let wallet_id = &wallet_address.id;
-    let grant_request = GrantRequest {
-        access_token: AccessTokenRequest {
+    let grant_request = GrantRequest::new(
+        AccessTokenRequest {
             access: vec![AccessItem::OutgoingPayment {
                 actions: vec![
                     OutgoingPaymentAction::Read,
@@ -44,8 +44,7 @@ async fn main() -> open_payments::client::Result<()> {
                 }),
             }],
         },
-        client: wallet_id.to_string(),
-        interact: Some(InteractRequest {
+        Some(InteractRequest {
             start: vec!["redirect".to_string()],
             finish: Some(InteractFinish {
                 method: "redirect".to_string(),
@@ -53,7 +52,7 @@ async fn main() -> open_payments::client::Result<()> {
                 nonce: Uuid::new_v4().to_string(),
             }),
         }),
-    };
+    );
 
     println!(
         "Grant request JSON: {}",

--- a/src/snippets/grant/quote.rs
+++ b/src/snippets/grant/quote.rs
@@ -16,15 +16,14 @@ async fn main() -> open_payments::client::Result<()> {
     let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let wallet_address = client.wallet_address().get(&wallet_address_url).await?;
 
-    let grant_request = GrantRequest {
-        access_token: AccessTokenRequest {
+    let grant_request = GrantRequest::new(
+        AccessTokenRequest {
             access: vec![AccessItem::Quote {
                 actions: vec![QuoteAction::Create, QuoteAction::Read, QuoteAction::ReadAll],
             }],
         },
-        client: wallet_address.id,
-        interact: None,
-    };
+        None,
+    );
 
     println!(
         "Grant request JSON: {}",

--- a/src/snippets/utils/mod.rs
+++ b/src/snippets/utils/mod.rs
@@ -15,15 +15,17 @@ pub fn get_env_var(key: &str) -> Result<String> {
 }
 
 pub fn create_authenticated_client() -> Result<AuthenticatedClient> {
+    let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
     let private_key_path = PathBuf::from(get_env_var("PRIVATE_KEY_PATH")?);
     let key_id = get_env_var("KEY_ID")?;
     let key_id_clone = key_id.clone();
     let jwks_path = get_env_var("JWKS_PATH").map(PathBuf::from).ok();
 
     let config = ClientConfig {
-        private_key_path,
         key_id,
+        private_key_path,
         jwks_path,
+        wallet_address_url,
     };
 
     let client = AuthenticatedClient::new(config)

--- a/src/types/auth.rs
+++ b/src/types/auth.rs
@@ -81,9 +81,19 @@ pub struct AccessTokenResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GrantRequest {
     pub access_token: AccessTokenRequest,
-    pub client: String,
+    pub(crate) client: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interact: Option<InteractRequest>,
+}
+
+impl GrantRequest {
+    pub fn new(access_token: AccessTokenRequest, interact: Option<InteractRequest>) -> Self {
+        Self {
+            access_token,
+            client: String::new(), // Will be set by the client internally
+            interact,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -36,16 +36,15 @@
 //! };
 //!
 //! // Create a grant request for incoming payment
-//! let grant_request = GrantRequest {
-//!     access_token: AccessTokenRequest {
+//! let grant_request = GrantRequest::new(
+//!     AccessTokenRequest {
 //!         access: vec![AccessItem::IncomingPayment {
 //!             actions: vec![IncomingPaymentAction::Create, IncomingPaymentAction::Read],
 //!             identifier: None,
 //!         }],
 //!     },
-//!     client: "https://rafiki.money/alice".to_string(),
-//!     interact: None,
-//! };
+//!     None,
+//! );
 //!
 //! // Create an incoming payment request
 //! let payment_request = CreateIncomingPaymentRequest {

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -32,6 +32,7 @@ impl TestSetup {
         let config = ClientConfig {
             key_id,
             private_key_path: private_key_path.into(),
+            wallet_address_url: wallet_address.clone(),
             ..Default::default()
         };
 

--- a/tests/integration/grant.rs
+++ b/tests/integration/grant.rs
@@ -15,8 +15,8 @@ async fn test_grant_flows() {
         .await
         .expect("Failed to get wallet address");
 
-    let grant_request = GrantRequest {
-        access_token: AccessTokenRequest {
+    let grant_request = GrantRequest::new(
+        AccessTokenRequest {
             access: vec![AccessItem::IncomingPayment {
                 actions: vec![
                     IncomingPaymentAction::Create,
@@ -28,9 +28,8 @@ async fn test_grant_flows() {
                 identifier: None,
             }],
         },
-        client: wallet_address.id,
-        interact: None,
-    };
+        None,
+    );
 
     let response = test_setup
         .auth_client

--- a/tests/integration/incoming_payment.rs
+++ b/tests/integration/incoming_payment.rs
@@ -13,8 +13,8 @@ async fn get_access_token(test_setup: &mut TestSetup) -> String {
         .await
         .expect("Failed to get wallet address");
 
-    let grant_request = GrantRequest {
-        access_token: AccessTokenRequest {
+    let grant_request = GrantRequest::new(
+        AccessTokenRequest {
             access: vec![AccessItem::IncomingPayment {
                 actions: vec![
                     IncomingPaymentAction::Create,
@@ -26,9 +26,8 @@ async fn get_access_token(test_setup: &mut TestSetup) -> String {
                 identifier: None,
             }],
         },
-        client: wallet_address.id,
-        interact: None,
-    };
+        None,
+    );
 
     let response = test_setup
         .auth_client

--- a/tests/integration/quote.rs
+++ b/tests/integration/quote.rs
@@ -13,8 +13,8 @@ async fn get_access_token(test_setup: &mut TestSetup) -> String {
         .await
         .expect("Failed to get wallet address");
 
-    let grant_request = GrantRequest {
-        access_token: AccessTokenRequest {
+    let grant_request = GrantRequest::new(
+        AccessTokenRequest {
             access: vec![
                 AccessItem::IncomingPayment {
                     actions: vec![IncomingPaymentAction::Create, IncomingPaymentAction::Read],
@@ -25,9 +25,8 @@ async fn get_access_token(test_setup: &mut TestSetup) -> String {
                 },
             ],
         },
-        client: wallet_address.id,
-        interact: None,
-    };
+        None,
+    );
 
     let response = test_setup
         .auth_client

--- a/tests/integration/token.rs
+++ b/tests/integration/token.rs
@@ -12,16 +12,15 @@ async fn get_access_token(test_setup: &mut TestSetup) -> AccessToken {
         .await
         .expect("Failed to get wallet address");
 
-    let grant_request = GrantRequest {
-        access_token: AccessTokenRequest {
+    let grant_request = GrantRequest::new(
+        AccessTokenRequest {
             access: vec![AccessItem::IncomingPayment {
                 actions: vec![IncomingPaymentAction::Create, IncomingPaymentAction::Read],
                 identifier: None,
             }],
         },
-        client: wallet_address.id,
-        interact: None,
-    };
+        None,
+    );
 
     let response = test_setup
         .auth_client


### PR DESCRIPTION
## Changes proposed in this pull request

This PR removes the `client` field on the `GrantRequest` type and sets it internally (in the client code) when building the request.

## Context

fixes #15 