### PR TITLE
17 update error types to match other sdks

### DIFF
--- a/src/client/core.rs
+++ b/src/client/core.rs
@@ -73,19 +73,23 @@ impl AuthenticatedOpenPaymentsClient {
     ///
     /// # Errors
     ///
-    /// - `OpClientError::Signature` if the signing key cannot be loaded or generated
-    /// - `OpClientError::Signature` if JWKS cannot be saved to the specified path
+    /// Returns an `OpClientError` with:
+    /// - `description`: Human-readable error message
+    /// - `status`: HTTP status text (for HTTP errors)
+    /// - `code`: HTTP status code (for HTTP errors)
+    /// - `validation_errors`: List of validation errors (if applicable)
+    /// - `details`: Additional error details (if applicable)
     pub fn new(config: ClientConfig) -> Result<Self> {
         let http_client = ReqwestClient::new();
 
         let signing_key = load_or_generate_key(&config.private_key_path).map_err(|e| {
-            OpClientError::Signature(format!("Failed to load or generate signing key: {e}"))
+            OpClientError::signature(format!("Failed to load or generate signing key: {e}"))
         })?;
 
         if let Some(ref jwks_path) = config.jwks_path {
             let jwks_json = Jwk::generate_jwks_json(&signing_key, &config.key_id);
             Jwk::save_jwks(&jwks_json, jwks_path).map_err(|e| {
-                OpClientError::Signature(format!("Failed to save JWK to file: {e}"))
+                OpClientError::signature(format!("Failed to save JWK to file: {e}"))
             })?;
         }
 

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -4,12 +4,13 @@
 //! All client operations return a [`Result<T, OpClientError>`] which provides
 //! detailed error information for different failure scenarios.
 //!
-//! ## Error Categories
+//! ## Error Structure
 //!
-//! - **HTTP Errors**: Network and HTTP protocol errors
-//! - **Parsing Errors**: Header, URL, and data parsing failures
-//! - **Cryptographic Errors**: Key and signature-related issues
-//! - **I/O Errors**: File system and network I/O problems
+//! - `description` - Human-readable error message
+//! - `validationErrors` - Optional list of validation error messages
+//! - `status` - HTTP status code (only for HTTP errors)
+//! - `code` - Error code (only for HTTP errors)
+//! - `details` - Additional error details as key-value pairs
 //!
 //! ## Example Usage
 //!
@@ -19,113 +20,181 @@
 //! fn handle_client_error(result: Result<()>) {
 //!     match result {
 //!         Ok(()) => println!("Operation successful"),
-//!         Err(OpClientError::Http(msg)) => eprintln!("HTTP error: {}", msg),
-//!         Err(OpClientError::Signature(msg)) => eprintln!("Signature error: {}", msg),
-//!         Err(OpClientError::Other(msg)) => eprintln!("Other error: {}", msg),
-//!         Err(e) => eprintln!("Unexpected error: {:?}", e),
+//!         Err(e) => {
+//!             eprintln!("Error: {}", e.description);
+//!             if let Some(status) = e.status {
+//!                 eprintln!("Status: {}", status);
+//!             }
+//!             if let Some(code) = e.code {
+//!                 eprintln!("Code: {}", code);
+//!             }
+//!             if let Some(validation_errors) = e.validation_errors {
+//!                 for error in validation_errors {
+//!                     eprintln!("Validation error: {}", error);
+//!                 }
+//!             }
+//!         }
 //!     }
 //! }
 //! ```
 
+use std::collections::HashMap;
 use thiserror::Error;
 
 /// Error type for Open Payments client operations.
 ///
-/// This enum provides detailed error information for different types of failures
-/// that can occur during client operations. Each variant includes context-specific
-/// error messages to help with debugging and error handling.
+/// ## Fields
 ///
-/// ## Error Variants
-///
-/// - `Http` - Network and HTTP protocol errors
-/// - `HeaderParse` - HTTP header parsing failures
-/// - `Serde` - JSON serialization/deserialization errors
-/// - `Io` - File system and I/O errors
-/// - `Pem` - PEM format parsing errors
-/// - `Pkcs8` - PKCS8 key format errors
-/// - `Base64` - Base64 encoding/decoding errors
-/// - `Url` - URL parsing errors
-/// - `Signature` - Cryptographic signature errors
-/// - `Other` - Miscellaneous errors
+/// - `description` - Human-readable error message
+/// - `validation_errors` - Optional list of validation error messages
+/// - `status` - HTTP status code (only relevant for HTTP errors)
+/// - `code` - Error code (only relevant for HTTP errors)
+/// - `details` - Additional error details as key-value pairs
 #[derive(Debug, Error)]
-pub enum OpClientError {
-    /// HTTP protocol or network-related errors.
-    ///
-    /// This includes connection failures, timeout errors, and HTTP status code errors.
-    /// The error message provides details about the specific HTTP issue.
-    #[error("HTTP error: {0}")]
-    Http(String),
+pub struct OpClientError {
+    /// Human-readable error description.
+    pub description: String,
 
-    /// HTTP header parsing errors.
-    ///
-    /// Occurs when the client cannot parse required HTTP headers such as
-    /// `Content-Type`, `Authorization`, or custom headers.
-    #[error("Header parse error: {0}")]
-    HeaderParse(String),
+    /// Optional list of validation error messages.
+    pub validation_errors: Option<Vec<String>>,
 
-    /// JSON serialization or deserialization errors.
-    ///
-    /// This error is automatically converted from `serde_json::Error` and occurs
-    /// when the client cannot serialize request data or deserialize response data.
-    #[error("Serde error: {0}")]
-    Serde(#[from] serde_json::Error),
+    /// HTTP status (only relevant for HTTP errors).
+    pub status: Option<String>,
 
-    /// File system and I/O errors.
-    ///
-    /// This error is automatically converted from `std::io::Error` and occurs
-    /// when the client cannot read key files or perform other I/O operations.
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
+    /// Error code (only relevant for HTTP errors).
+    pub code: Option<u16>,
 
-    /// PEM format parsing errors.
-    ///
-    /// Occurs when the client cannot parse PEM-encoded private keys or certificates.
-    /// This includes malformed PEM files or unsupported PEM types.
-    #[error("Invalid PEM: {0}")]
-    Pem(String),
+    /// Additional error details as key-value pairs.
+    pub details: Option<HashMap<String, serde_json::Value>>,
+}
 
-    /// PKCS8 key format errors.
-    ///
-    /// Occurs when the client cannot parse PKCS8-encoded private keys.
-    /// This includes unsupported key algorithms or malformed key data.
-    #[error("PKCS8 error: {0}")]
-    Pkcs8(String),
+impl OpClientError {
+    /// Creates a new HTTP error with status code and optional error code.
+    pub fn http(description: impl Into<String>, status: Option<String>, code: Option<u16>) -> Self {
+        Self {
+            description: description.into(),
+            validation_errors: None,
+            status,
+            code,
+            details: None,
+        }
+    }
 
-    /// Base64 encoding or decoding errors.
-    ///
-    /// This error is automatically converted from `base64::DecodeError` and occurs
-    /// when the client cannot decode Base64-encoded data such as signatures or keys.
-    #[error("Base64 error: {0}")]
-    Base64(#[from] base64::DecodeError),
+    /// Creates a new validation error with a list of validation messages.
+    pub fn validation(description: impl Into<String>, validation_errors: Vec<String>) -> Self {
+        Self {
+            description: description.into(),
+            validation_errors: Some(validation_errors),
+            status: None,
+            code: None,
+            details: None,
+        }
+    }
 
-    /// URL parsing errors.
-    ///
-    /// This error is automatically converted from `url::ParseError` and occurs
-    /// when the client cannot parse URLs for wallet addresses or API endpoints.
-    #[error("URL parse error: {0}")]
-    Url(#[from] url::ParseError),
+    /// Creates a new general error without HTTP-specific fields.
+    pub fn other(description: impl Into<String>) -> Self {
+        Self {
+            description: description.into(),
+            validation_errors: None,
+            status: None,
+            code: None,
+            details: None,
+        }
+    }
 
-    /// Cryptographic signature errors.
-    ///
-    /// Occurs when there are issues with HTTP message signature creation or validation.
-    /// This includes key loading failures, signature generation errors, and validation failures.
-    #[error("Signature error: {0}")]
-    Signature(String),
+    /// Adds additional details to the error.
+    pub fn with_details(mut self, details: HashMap<String, serde_json::Value>) -> Self {
+        self.details = Some(details);
+        self
+    }
 
-    /// Miscellaneous errors that don't fit into other categories.
-    ///
-    /// This variant is used for unexpected errors that don't fall into the standard error categories.
-    #[error("Other error: {0}")]
-    Other(String),
+    /// Adds a single detail key-value pair to the error.
+    pub fn with_detail(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
+        if self.details.is_none() {
+            self.details = Some(HashMap::new());
+        }
+        if let Some(ref mut details) = self.details {
+            details.insert(key.into(), value);
+        }
+        self
+    }
+}
+
+impl std::fmt::Display for OpClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.description)?;
+
+        if let Some(status) = &self.status {
+            write!(f, " (Status: {})", status)?;
+        }
+
+        if let Some(code) = &self.code {
+            write!(f, " (Code: {})", code)?;
+        }
+
+        if let Some(validation_errors) = &self.validation_errors {
+            write!(f, " [Validation errors: {}]", validation_errors.join(", "))?;
+        }
+
+        Ok(())
+    }
 }
 
 impl From<reqwest::Error> for OpClientError {
-    /// Converts reqwest HTTP errors to `OpClientError::Http`.
-    ///
-    /// This implementation allows the client to automatically convert reqwest errors
-    /// into the unified error type, providing consistent error handling across the library.
     fn from(err: reqwest::Error) -> Self {
-        OpClientError::Http(format!("{err}"))
+        let status = err.status().map(|s| s.to_string());
+        let code = err.status().map(|s| s.as_u16());
+        let description = format!("HTTP error: {}", err);
+
+        Self {
+            description,
+            validation_errors: None,
+            status,
+            code,
+            details: None,
+        }
+    }
+}
+
+impl From<serde_json::Error> for OpClientError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::other(format!("JSON serialization/deserialization error: {}", err))
+    }
+}
+
+impl From<std::io::Error> for OpClientError {
+    fn from(err: std::io::Error) -> Self {
+        Self::other(format!("I/O error: {}", err))
+    }
+}
+
+impl From<base64::DecodeError> for OpClientError {
+    fn from(err: base64::DecodeError) -> Self {
+        Self::other(format!("Base64 decoding error: {}", err))
+    }
+}
+
+impl From<url::ParseError> for OpClientError {
+    fn from(err: url::ParseError) -> Self {
+        Self::other(format!("URL parsing error: {}", err))
+    }
+}
+
+impl OpClientError {
+    pub fn header_parse(description: impl Into<String>) -> Self {
+        Self::other(format!("Header parse error: {}", description.into()))
+    }
+
+    pub fn pem(description: impl Into<String>) -> Self {
+        Self::other(format!("Invalid PEM: {}", description.into()))
+    }
+
+    pub fn pkcs8(description: impl Into<String>) -> Self {
+        Self::other(format!("PKCS8 error: {}", description.into()))
+    }
+
+    pub fn signature(description: impl Into<String>) -> Self {
+        Self::other(format!("Signature error: {}", description.into()))
     }
 }
 

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -125,11 +125,11 @@ impl std::fmt::Display for OpClientError {
         write!(f, "{}", self.description)?;
 
         if let Some(status) = &self.status {
-            write!(f, " (Status: {})", status)?;
+            write!(f, " (Status: {status})")?;
         }
 
         if let Some(code) = &self.code {
-            write!(f, " (Code: {})", code)?;
+            write!(f, " (Code: {code})")?;
         }
 
         if let Some(validation_errors) = &self.validation_errors {
@@ -144,7 +144,7 @@ impl From<reqwest::Error> for OpClientError {
     fn from(err: reqwest::Error) -> Self {
         let status = err.status().map(|s| s.to_string());
         let code = err.status().map(|s| s.as_u16());
-        let description = format!("HTTP error: {}", err);
+        let description = format!("HTTP error: {err}");
 
         Self {
             description,
@@ -158,25 +158,25 @@ impl From<reqwest::Error> for OpClientError {
 
 impl From<serde_json::Error> for OpClientError {
     fn from(err: serde_json::Error) -> Self {
-        Self::other(format!("JSON serialization/deserialization error: {}", err))
+        Self::other(format!("JSON serialization/deserialization error: {err}"))
     }
 }
 
 impl From<std::io::Error> for OpClientError {
     fn from(err: std::io::Error) -> Self {
-        Self::other(format!("I/O error: {}", err))
+        Self::other(format!("I/O error: {err}"))
     }
 }
 
 impl From<base64::DecodeError> for OpClientError {
     fn from(err: base64::DecodeError) -> Self {
-        Self::other(format!("Base64 decoding error: {}", err))
+        Self::other(format!("Base64 decoding error: {err}"))
     }
 }
 
 impl From<url::ParseError> for OpClientError {
     fn from(err: url::ParseError) -> Self {
-        Self::other(format!("URL parsing error: {}", err))
+        Self::other(format!("URL parsing error: {err}"))
     }
 }
 
@@ -198,8 +198,38 @@ impl OpClientError {
     }
 }
 
+impl From<url::ParseError> for Box<OpClientError> {
+    fn from(err: url::ParseError) -> Self {
+        Box::new(OpClientError::from(err))
+    }
+}
+
+impl From<reqwest::Error> for Box<OpClientError> {
+    fn from(err: reqwest::Error) -> Self {
+        Box::new(OpClientError::from(err))
+    }
+}
+
+impl From<serde_json::Error> for Box<OpClientError> {
+    fn from(err: serde_json::Error) -> Self {
+        Box::new(OpClientError::from(err))
+    }
+}
+
+impl From<std::io::Error> for Box<OpClientError> {
+    fn from(err: std::io::Error) -> Self {
+        Box::new(OpClientError::from(err))
+    }
+}
+
+impl From<base64::DecodeError> for Box<OpClientError> {
+    fn from(err: base64::DecodeError) -> Self {
+        Box::new(OpClientError::from(err))
+    }
+}
+
 /// Result type for Open Payments client operations.
 ///
-/// This is a type alias for `Result<T, OpClientError>` that provides a convenient
+/// This is a type alias for `Result<T, Box<OpClientError>>` that provides a convenient
 /// way to handle client operation results with detailed error information.
-pub type Result<T> = std::result::Result<T, OpClientError>;
+pub type Result<T> = std::result::Result<T, Box<OpClientError>>;

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -142,7 +142,9 @@ impl std::fmt::Display for OpClientError {
 
 impl From<reqwest::Error> for OpClientError {
     fn from(err: reqwest::Error) -> Self {
-        let status = err.status().map(|s| s.to_string());
+        let status = err
+            .status()
+            .map(|s| s.canonical_reason().unwrap_or("Unknown").to_string());
         let code = err.status().map(|s| s.as_u16());
         let description = format!("HTTP error: {err}");
 

--- a/src/client/grant.rs
+++ b/src/client/grant.rs
@@ -14,7 +14,7 @@ pub(crate) async fn request_grant(
         client: client.config.wallet_address_url.clone(),
         ..grant.clone()
     };
-    let body = serde_json::to_string(&grant_with_client).map_err(OpClientError::Serde)?;
+    let body = serde_json::to_string(&grant_with_client).map_err(OpClientError::from)?;
 
     AuthenticatedRequest::new(client, Method::POST, auth_url.to_string())
         .with_body(body)
@@ -31,7 +31,7 @@ pub(crate) async fn continue_grant(
     let body = serde_json::to_string(&ContinueRequest {
         interact_ref: Some(interact_ref.to_string()),
     })
-    .map_err(OpClientError::Serde)?;
+    .map_err(OpClientError::from)?;
 
     AuthenticatedRequest::new(client, Method::POST, continue_uri.to_string())
         .with_body(body)

--- a/src/client/payments.rs
+++ b/src/client/payments.rs
@@ -17,7 +17,7 @@ pub(crate) async fn create_incoming_payment(
     access_token: Option<&str>,
 ) -> Result<IncomingPayment> {
     let url = join_url_paths(resource_server_url, "incoming-payments")?;
-    let body = serde_json::to_string(req_body).map_err(OpClientError::Serde)?;
+    let body = serde_json::to_string(req_body).map_err(OpClientError::from)?;
 
     AuthenticatedRequest::new(client, Method::POST, url)
         .with_body(body)
@@ -84,7 +84,7 @@ pub(crate) async fn create_outgoing_payment(
     access_token: Option<&str>,
 ) -> Result<OutgoingPayment> {
     let url = join_url_paths(resource_server_url, "outgoing-payments")?;
-    let body = serde_json::to_string(req_body).map_err(OpClientError::Serde)?;
+    let body = serde_json::to_string(req_body).map_err(OpClientError::from)?;
 
     AuthenticatedRequest::new(client, Method::POST, url)
         .with_body(body)

--- a/src/client/quotes.rs
+++ b/src/client/quotes.rs
@@ -13,7 +13,7 @@ pub(crate) async fn create_quote(
     access_token: Option<&str>,
 ) -> Result<Quote> {
     let url = join_url_paths(resource_server_url, "quotes")?;
-    let body = serde_json::to_string(req_body).map_err(OpClientError::Serde)?;
+    let body = serde_json::to_string(req_body).map_err(OpClientError::from)?;
 
     AuthenticatedRequest::new(client, Method::POST, url)
         .with_body(body)

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -123,10 +123,12 @@ impl AuthenticatedRequest<'_> {
     ///
     /// ## Errors
     ///
-    /// - `OpClientError::HeaderParse` if headers cannot be parsed
-    /// - `OpClientError::Signature` if signature creation fails
-    /// - `OpClientError::Http` if the HTTP request fails
-    /// - `OpClientError::Serde` if response deserialization fails
+    /// Returns an `OpClientError` with:
+    /// - `description`: Human-readable error message
+    /// - `status`: HTTP status text (for HTTP errors)
+    /// - `code`: HTTP status code (for HTTP errors)
+    /// - `validation_errors`: List of validation errors (if applicable)
+    /// - `details`: Additional error details (if applicable)
     pub async fn build_and_execute<T: DeserializeOwned + 'static>(
         self,
         access_token: Option<&str>,
@@ -137,7 +139,9 @@ impl AuthenticatedRequest<'_> {
             req.headers_mut().insert(
                 "Authorization",
                 format!("GNAP {token}").parse().map_err(|e| {
-                    OpClientError::HeaderParse(format!("Failed to parse authorization header: {e}"))
+                    OpClientError::header_parse(format!(
+                        "Failed to parse authorization header: {e}"
+                    ))
                 })?,
             );
         }
@@ -146,13 +150,13 @@ impl AuthenticatedRequest<'_> {
             req.headers_mut().insert(
                 "Content-Length",
                 content_length.to_string().parse().map_err(|e| {
-                    OpClientError::HeaderParse(format!("Failed to parse content length: {e}"))
+                    OpClientError::header_parse(format!("Failed to parse content length: {e}"))
                 })?,
             );
             req.headers_mut().insert(
                 "Content-Digest",
                 content_digest.parse().map_err(|e| {
-                    OpClientError::HeaderParse(format!("Failed to parse content digest: {e}"))
+                    OpClientError::header_parse(format!("Failed to parse content digest: {e}"))
                 })?,
             );
         }
@@ -162,13 +166,13 @@ impl AuthenticatedRequest<'_> {
         req.headers_mut().insert(
             "Signature",
             signature.parse().map_err(|e| {
-                OpClientError::HeaderParse(format!("Failed to parse signature header: {e}"))
+                OpClientError::header_parse(format!("Failed to parse signature header: {e}"))
             })?,
         );
         req.headers_mut().insert(
             "Signature-Input",
             signature_input.parse().map_err(|e| {
-                OpClientError::HeaderParse(format!("Failed to parse signature input header: {e}"))
+                OpClientError::header_parse(format!("Failed to parse signature input header: {e}"))
             })?,
         );
 
@@ -193,18 +197,19 @@ impl AuthenticatedRequest<'_> {
         // Convert to http::Request for signing
         let mut http_req = Request::new(self.body.clone());
         *http_req.method_mut() = HttpMethod::from_bytes(req.method().as_str().as_bytes())
-            .map_err(|e| OpClientError::HeaderParse(format!("Converting HTTP method: {e}")))?;
+            .map_err(|e| OpClientError::header_parse(format!("Converting HTTP method: {e}")))?;
         *http_req.uri_mut() = req
             .url()
             .as_str()
             .parse()
-            .map_err(|e| OpClientError::HeaderParse(format!("Converting URL to URI: {e}")))?;
+            .map_err(|e| OpClientError::header_parse(format!("Converting URL to URI: {e}")))?;
 
         for (key, value) in req.headers() {
             let header_name = HeaderName::from_bytes(key.as_str().as_bytes())
-                .map_err(|e| OpClientError::HeaderParse(format!("Converting header name: {e}")))?;
-            let header_value = HeaderValue::from_bytes(value.as_bytes())
-                .map_err(|e| OpClientError::HeaderParse(format!("Converting header value: {e}")))?;
+                .map_err(|e| OpClientError::header_parse(format!("Converting header name: {e}")))?;
+            let header_value = HeaderValue::from_bytes(value.as_bytes()).map_err(|e| {
+                OpClientError::header_parse(format!("Converting header value: {e}"))
+            })?;
             http_req.headers_mut().insert(header_name, header_value);
         }
 
@@ -215,7 +220,7 @@ impl AuthenticatedRequest<'_> {
             self.client.config.key_id.clone(),
         );
         let headers = create_signature_headers(options)
-            .map_err(|e| OpClientError::Signature(e.to_string()))?;
+            .map_err(|e| OpClientError::signature(e.to_string()))?;
 
         Ok((headers.signature, headers.signature_input))
     }
@@ -263,8 +268,12 @@ impl UnauthenticatedRequest<'_> {
     ///
     /// ## Errors
     ///
-    /// - `OpClientError::Http` if the HTTP request fails
-    /// - `OpClientError::Serde` if response deserialization fails
+    /// Returns an `OpClientError` with:
+    /// - `description`: Human-readable error message
+    /// - `status`: HTTP status text (for HTTP errors)
+    /// - `code`: HTTP status code (for HTTP errors)
+    /// - `validation_errors`: List of validation errors (if applicable)
+    /// - `details`: Additional error details (if applicable)
     pub async fn build_and_execute<T: DeserializeOwned + 'static>(self) -> Result<T> {
         let req = build_request(&self)?;
         execute_request(self.client, req).await
@@ -319,8 +328,12 @@ fn build_request<C: BaseClient>(req: &HttpRequest<C>) -> Result<reqwest::Request
 ///
 /// ## Errors
 ///
-/// - `OpClientError::Http` if the HTTP status code indicates failure
-/// - `OpClientError::Serde` if response deserialization fails
+/// Returns an `OpClientError` with:
+/// - `description`: Human-readable error message
+/// - `status`: HTTP status text (for HTTP errors)
+/// - `code`: HTTP status code (for HTTP errors)
+/// - `validation_errors`: List of validation errors (if applicable)
+/// - `details`: Additional error details (if applicable)
 async fn execute_request<T: DeserializeOwned + 'static>(
     client: &Client,
     req: reqwest::Request,
@@ -328,10 +341,16 @@ async fn execute_request<T: DeserializeOwned + 'static>(
     let resp = client.execute(req).await.map_err(OpClientError::from)?;
 
     if !resp.status().is_success() {
-        return Err(OpClientError::Http(format!(
-            "Request failed: HTTP {}",
-            resp.status()
-        )));
+        return Err(OpClientError::http(
+            "HTTP request failed".to_string(),
+            Some(
+                resp.status()
+                    .canonical_reason()
+                    .unwrap_or("Unknown")
+                    .to_string(),
+            ),
+            Some(resp.status().as_u16()),
+        ));
     }
 
     if resp.status() == reqwest::StatusCode::NO_CONTENT

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -27,9 +27,14 @@ use url::Url;
 ///
 /// ## Errors
 ///
-/// - `OpClientError::Url` if the wallet address URL cannot be parsed
+/// Returns an `OpClientError` with:
+/// - `description`: Human-readable error message
+/// - `status`: HTTP status text (for HTTP errors)
+/// - `code`: HTTP status code (for HTTP errors)
+/// - `validation_errors`: List of validation errors (if applicable)
+/// - `details`: Additional error details (if applicable)
 pub fn get_resource_server_url(wallet_address_url: &str) -> Result<String> {
-    let url = Url::parse(wallet_address_url).map_err(OpClientError::Url)?;
+    let url = Url::parse(wallet_address_url).map_err(OpClientError::from)?;
 
     let path_segments: Vec<&str> = url
         .path_segments()
@@ -71,9 +76,14 @@ pub fn get_resource_server_url(wallet_address_url: &str) -> Result<String> {
 ///
 /// ## Errors
 ///
-/// - `OpClientError::Url` if the base URL cannot be parsed or the path cannot be joined
+/// Returns an `OpClientError` with:
+/// - `description`: Human-readable error message
+/// - `status`: HTTP status text (for HTTP errors)
+/// - `code`: HTTP status code (for HTTP errors)
+/// - `validation_errors`: List of validation errors (if applicable)
+/// - `details`: Additional error details (if applicable)
 pub fn join_url_paths(base_url: &str, path: &str) -> Result<String> {
-    let mut url = Url::parse(base_url).map_err(OpClientError::Url)?;
+    let mut url = Url::parse(base_url).map_err(OpClientError::from)?;
 
     if path.is_empty() {
         return Ok(url.to_string());
@@ -83,6 +93,6 @@ pub fn join_url_paths(base_url: &str, path: &str) -> Result<String> {
         url.set_path(&format!("{}/", url.path()));
     }
 
-    let joined_url = url.join(path).map_err(OpClientError::Url)?;
+    let joined_url = url.join(path).map_err(OpClientError::from)?;
     Ok(joined_url.to_string())
 }

--- a/src/snippets/incoming_payment/create.rs
+++ b/src/snippets/incoming_payment/create.rs
@@ -7,7 +7,7 @@ use open_payments::types::{resource::CreateIncomingPaymentRequest, Amount};
 
 #[tokio::main]
 async fn main() -> open_payments::client::Result<()> {
-    load_env().map_err(|e| OpClientError::Other(e.to_string()))?;
+    load_env().map_err(|e| OpClientError::other(e.to_string()))?;
 
     let client = create_authenticated_client()?;
 

--- a/src/snippets/utils/mod.rs
+++ b/src/snippets/utils/mod.rs
@@ -11,7 +11,7 @@ pub fn load_env() -> Result<()> {
 }
 
 pub fn get_env_var(key: &str) -> Result<String> {
-    env::var(key).map_err(|_| OpClientError::Other(format!("{key} environment variable not set")))
+    env::var(key).map_err(|_| OpClientError::other(format!("{key} environment variable not set")))
 }
 
 pub fn create_authenticated_client() -> Result<AuthenticatedClient> {
@@ -29,9 +29,9 @@ pub fn create_authenticated_client() -> Result<AuthenticatedClient> {
     };
 
     let client = AuthenticatedClient::new(config)
-        .map_err(|e| OpClientError::Other(format!("Client creation error: {e}")))?;
+        .map_err(|e| OpClientError::other(format!("Client creation error: {e}")))?;
     Jwk::new(key_id_clone, Some(&client.signing_key))
-        .map_err(|e| OpClientError::Other(format!("JWK error: {e}")))?;
+        .map_err(|e| OpClientError::other(format!("JWK error: {e}")))?;
     Ok(client)
 }
 

--- a/src/snippets/utils/mod.rs
+++ b/src/snippets/utils/mod.rs
@@ -11,7 +11,7 @@ pub fn load_env() -> Result<()> {
 }
 
 pub fn get_env_var(key: &str) -> Result<String> {
-    env::var(key).map_err(|_| OpClientError::other(format!("{key} environment variable not set")))
+    Ok(env::var(key).map_err(|_| OpClientError::other(format!("{key} environment variable not set")))?)
 }
 
 pub fn create_authenticated_client() -> Result<AuthenticatedClient> {

--- a/src/snippets/utils/mod.rs
+++ b/src/snippets/utils/mod.rs
@@ -11,7 +11,8 @@ pub fn load_env() -> Result<()> {
 }
 
 pub fn get_env_var(key: &str) -> Result<String> {
-    Ok(env::var(key).map_err(|_| OpClientError::other(format!("{key} environment variable not set")))?)
+    Ok(env::var(key)
+        .map_err(|_| OpClientError::other(format!("{key} environment variable not set")))?)
 }
 
 pub fn create_authenticated_client() -> Result<AuthenticatedClient> {

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -13,20 +13,20 @@ pub struct TestSetup {
 impl TestSetup {
     pub async fn new() -> Result<Self> {
         dotenv::from_filename("tests/integration/.env").map_err(|_| {
-            OpClientError::Other(".env file not found in tests/integration directory".into())
+            OpClientError::other(".env file not found in tests/integration directory".to_string())
         })?;
 
         let resource_server_url = env::var("OPEN_PAYMENTS_SERVER_URL").map_err(|_| {
-            OpClientError::Other("OPEN_PAYMENTS_SERVER_URL not set in .env file".into())
+            OpClientError::other("OPEN_PAYMENTS_SERVER_URL not set in .env file".to_string())
         })?;
         let wallet_address = env::var("OPEN_PAYMENTS_WALLET_ADDRESS").map_err(|_| {
-            OpClientError::Other("OPEN_PAYMENTS_WALLET_ADDRESS not set in .env file".into())
+            OpClientError::other("OPEN_PAYMENTS_WALLET_ADDRESS not set in .env file".to_string())
         })?;
         let key_id = env::var("OPEN_PAYMENTS_KEY_ID").map_err(|_| {
-            OpClientError::Other("OPEN_PAYMENTS_KEY_ID not set in .env file".into())
+            OpClientError::other("OPEN_PAYMENTS_KEY_ID not set in .env file".to_string())
         })?;
         let private_key_path = env::var("OPEN_PAYMENTS_PRIVATE_KEY_PATH").map_err(|_| {
-            OpClientError::Other("OPEN_PAYMENTS_PRIVATE_KEY_PATH not set in .env file".into())
+            OpClientError::other("OPEN_PAYMENTS_PRIVATE_KEY_PATH not set in .env file".to_string())
         })?;
 
         let config = ClientConfig {


### PR DESCRIPTION
## Changes proposed in this pull request

This PR changes error handling of the client library such that errors have the same format as the Typescript SDK.

## Context

fixes #17
