### PR TITLE
fix: align HTTP signature format with RFC 9421 and RFC 9635 (GNAP)

### DIFF
--- a/src/http_signature/signatures.rs
+++ b/src/http_signature/signatures.rs
@@ -67,9 +67,16 @@ fn create_signature_base_string(
         parts.push(format!("\"{component}\": {value}"));
     }
 
+    // RFC 9421 Section 2.5: component identifiers in the signature params
+    // line MUST be quoted strings per the Structured Field sf-string type.
+    let quoted_components: Vec<String> = components
+        .iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect();
+
     let sig_params = format!(
-        "({});created={};keyid=\"{}\"",
-        components.join(" "),
+        "({});created={};keyid=\"{}\";tag=\"gnap\"",
+        quoted_components.join(" "),
         created,
         keyid
     );
@@ -94,11 +101,23 @@ pub fn create_signature_headers(options: SignOptions<'_>) -> Result<SignatureHea
         create_signature_base_string(options.request, &components, created, &options.key_id);
 
     let signature_bytes = options.private_key.sign(signature_base.as_bytes());
-    let signature = STANDARD.encode(signature_bytes.to_bytes());
+    let encoded_signature = STANDARD.encode(signature_bytes.to_bytes());
+
+    // RFC 9421 Section 4.2: Signature header uses Structured Field byte
+    // sequence format with colon delimiters: sig1=:base64:
+    let signature = format!("sig1=:{}:", encoded_signature);
+
+    // RFC 9421 Section 4.1: component identifiers in Signature-Input MUST
+    // be quoted strings. RFC 9635 Section 7.3.1: tag="gnap" is required
+    // for GNAP-bound signatures.
+    let quoted_components: Vec<String> = components
+        .iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect();
 
     let signature_input = format!(
-        "sig1=({});created={};keyid=\"{}\"",
-        components.join(" "),
+        "sig1=({});created={};keyid=\"{}\";tag=\"gnap\"",
+        quoted_components.join(" "),
         created,
         options.key_id
     );
@@ -131,5 +150,81 @@ mod tests {
         let headers = create_signature_headers(options).unwrap();
         assert!(!headers.signature.is_empty());
         assert!(!headers.signature_input.is_empty());
+    }
+
+    #[test]
+    fn test_signature_header_uses_byte_sequence_format() {
+        let mut request = Request::new(None::<String>);
+        *request.method_mut() = Method::GET;
+        *request.uri_mut() = Uri::from_static("http://example.com");
+        request
+            .headers_mut()
+            .insert("Content-Type", "application/json".parse().unwrap());
+
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let options = SignOptions::new(&request, &signing_key, "test-key".to_string());
+
+        let headers = create_signature_headers(options).unwrap();
+
+        // RFC 9421 Section 4.2: Signature uses byte sequence format sig1=:base64:
+        assert!(
+            headers.signature.starts_with("sig1=:"),
+            "Signature should start with 'sig1=:', got: {}",
+            headers.signature
+        );
+        assert!(
+            headers.signature.ends_with(':'),
+            "Signature should end with ':', got: {}",
+            headers.signature
+        );
+    }
+
+    #[test]
+    fn test_signature_input_has_quoted_components() {
+        let mut request = Request::new(None::<String>);
+        *request.method_mut() = Method::GET;
+        *request.uri_mut() = Uri::from_static("http://example.com");
+        request
+            .headers_mut()
+            .insert("Content-Type", "application/json".parse().unwrap());
+
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let options = SignOptions::new(&request, &signing_key, "key-1".to_string());
+
+        let headers = create_signature_headers(options).unwrap();
+
+        // RFC 9421 Section 2.5: component identifiers MUST be quoted strings
+        assert!(
+            headers.signature_input.contains("\"@method\""),
+            "Signature-Input should contain quoted component identifiers, got: {}",
+            headers.signature_input
+        );
+        assert!(
+            headers.signature_input.contains("\"@target-uri\""),
+            "Signature-Input should contain quoted component identifiers, got: {}",
+            headers.signature_input
+        );
+    }
+
+    #[test]
+    fn test_signature_input_has_gnap_tag() {
+        let mut request = Request::new(None::<String>);
+        *request.method_mut() = Method::GET;
+        *request.uri_mut() = Uri::from_static("http://example.com");
+        request
+            .headers_mut()
+            .insert("Content-Type", "application/json".parse().unwrap());
+
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let options = SignOptions::new(&request, &signing_key, "key-1".to_string());
+
+        let headers = create_signature_headers(options).unwrap();
+
+        // RFC 9635 Section 7.3.1: GNAP signatures MUST include tag="gnap"
+        assert!(
+            headers.signature_input.contains("tag=\"gnap\""),
+            "Signature-Input should contain tag=\"gnap\", got: {}",
+            headers.signature_input
+        );
     }
 }

--- a/src/http_signature/validation.rs
+++ b/src/http_signature/validation.rs
@@ -23,11 +23,14 @@ impl ValidationOptions<'_> {
     }
 }
 
-fn create_signature_base_string(
+/// Reconstructs the signature base string using the raw signature params from
+/// the Signature-Input header. This ensures the verifier uses the exact same
+/// params line that the signer used, including any additional parameters like
+/// `tag` or `nonce` that the verifier doesn't need to parse individually.
+fn create_signature_base_string_from_raw(
     request: &Request<Option<String>>,
     components: &[&str],
-    created: i64,
-    keyid: &str,
+    raw_params: &str,
 ) -> String {
     let mut parts = Vec::new();
 
@@ -60,30 +63,42 @@ fn create_signature_base_string(
         parts.push(format!("\"{component}\": {value}"));
     }
 
-    let sig_params = format!(
-        "({});created={};keyid=\"{}\"",
-        components.join(" "),
-        created,
-        keyid
-    );
-    parts.push(format!("\"@signature-params\": {sig_params}"));
+    // RFC 9421 Section 2.5: the @signature-params line uses the raw params
+    // string from the Signature-Input header to ensure exact match.
+    parts.push(format!("\"@signature-params\": {raw_params}"));
 
     parts.join("\n")
 }
 
-fn parse_signature_input(signature_input: &str) -> Result<(Vec<&str>, i64, String)> {
+/// Parsed signature input parameters.
+struct SignatureParams<'a> {
+    components: Vec<&'a str>,
+    _created: i64,
+    _keyid: String,
+    /// The raw signature params string (everything after sig1=) to use
+    /// when reconstructing the signature base. This ensures the verifier
+    /// uses the exact same params line that the signer used.
+    raw_params: &'a str,
+}
+
+fn parse_signature_input(signature_input: &str) -> Result<SignatureParams<'_>> {
     let mut components = Vec::new();
     let mut created = None;
     let mut keyid = None;
 
     // Remove the sig1= prefix if present
-    let signature_input = signature_input
+    let raw_params = signature_input
         .strip_prefix("sig1=")
         .unwrap_or(signature_input);
 
-    for part in signature_input.split(';') {
+    for part in raw_params.split(';') {
         if let Some(inner) = part.strip_prefix('(').and_then(|p| p.strip_suffix(')')) {
-            components = inner.split(' ').map(|s| s.trim()).collect();
+            // RFC 9421: component identifiers may be quoted strings.
+            // Strip quotes from each identifier for lookup.
+            components = inner
+                .split(' ')
+                .map(|s| s.trim().trim_matches('"'))
+                .collect();
         } else if let Some(value) = part.strip_prefix("created=") {
             created = value.parse::<i64>().ok();
         } else if let Some(value) = part.strip_prefix("keyid=") {
@@ -96,7 +111,12 @@ fn parse_signature_input(signature_input: &str) -> Result<(Vec<&str>, i64, Strin
     let keyid =
         keyid.ok_or_else(|| HttpSignatureError::Validation("Missing keyid field".to_string()))?;
 
-    Ok((components, created, keyid))
+    Ok(SignatureParams {
+        components,
+        _created: created,
+        _keyid: keyid,
+        raw_params,
+    })
 }
 
 pub fn validate_signature(options: ValidationOptions<'_>) -> Result<()> {
@@ -108,19 +128,31 @@ pub fn validate_signature(options: ValidationOptions<'_>) -> Result<()> {
             HttpSignatureError::Validation("Missing Signature-Input header".to_string())
         })?;
 
-    let (components, created, keyid) = parse_signature_input(signature_input)?;
+    let params = parse_signature_input(signature_input)?;
 
-    let signature = options
+    let raw_signature = options
         .headers
         .get("Signature")
         .and_then(|v| v.to_str().ok())
         .ok_or_else(|| HttpSignatureError::Validation("Missing Signature header".to_string()))?;
 
-    let signature_base =
-        create_signature_base_string(options.request, &components, created, &keyid);
+    // RFC 9421 Section 4.2: Signature header is a Dictionary Structured Field
+    // with byte sequence values in the format sig1=:base64:
+    // Also accept raw base64 for backwards compatibility.
+    let signature_b64 = raw_signature
+        .strip_prefix("sig1=:")
+        .and_then(|s| s.strip_suffix(':'))
+        .or_else(|| raw_signature.strip_prefix("sig1="))
+        .unwrap_or(raw_signature);
+
+    let signature_base = create_signature_base_string_from_raw(
+        options.request,
+        &params.components,
+        params.raw_params,
+    );
 
     let signature_bytes = STANDARD
-        .decode(signature)
+        .decode(signature_b64)
         .map_err(|_| HttpSignatureError::Validation("Base64 decode failed".to_string()))?;
 
     let signature_bytes: [u8; 64] = signature_bytes


### PR DESCRIPTION
## Summary

Fixes three RFC compliance issues in the HTTP message signature implementation:

1. **Quoted component identifiers** (RFC 9421 Section 2.5): Component identifiers in `Signature-Input` and the signature base's `@signature-params` line are now quoted strings per the Structured Field `sf-string` type.
   - Before: `sig1=(@method @target-uri content-type);created=...`
   - After: `sig1=("@method" "@target-uri" "content-type");created=...`

2. **Structured Field byte sequence for Signature** (RFC 9421 Section 4.2): The `Signature` header now uses the byte sequence format with colon delimiters.
   - Before: `<raw-base64>`
   - After: `sig1=:<base64>:`

3. **GNAP tag parameter** (RFC 9635 Section 7.3.1): Adds `tag="gnap"` to signature params, which is required for GNAP-bound signatures used by Open Payments.
   - Before: `sig1=(...);created=...;keyid="..."`
   - After: `sig1=(...);created=...;keyid="...";tag="gnap"`

## Validation changes

The verifier now:
- Strips quotes from component identifiers when parsing `Signature-Input`
- Parses the `sig1=:base64:` byte sequence format (with fallback to raw base64 for backwards compatibility)
- Uses the raw `@signature-params` string from `Signature-Input` when reconstructing the signature base, ensuring exact match with the signer regardless of additional parameters like `tag` or `nonce`

## References

- [RFC 9421: HTTP Message Signatures](https://www.rfc-editor.org/rfc/rfc9421) — Section 2.5, 4.1, 4.2
- [RFC 9635: GNAP](https://www.rfc-editor.org/rfc/rfc9635) — Section 7.3.1 (signature binding)
- [RFC 8941: Structured Field Values](https://www.rfc-editor.org/rfc/rfc8941) — byte sequence format

## Test plan

- [x] All 19 unit tests pass
- [x] All 10 client request tests pass
- [x] All 19 type roundtrip tests pass
- [x] New tests verify: byte sequence format, quoted components, GNAP tag
- [x] Sign → verify round-trip works end-to-end with new format
- [x] No clippy warnings