### PR TITLE
chore: upgrade reqwest from 0.11 to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "2.0.12"
 base64 = "0.22.1"
 ed25519-dalek = { version = "2.0", features = ["rand_core"] }
 http = "1.3.1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 sha2 = "0.10"
 url = "2.4"
 

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -23,10 +23,7 @@ use crate::OpClientError;
 use crate::Result;
 use base64::engine::general_purpose;
 use base64::Engine;
-use http::{
-    header::{HeaderName, HeaderValue},
-    Method as HttpMethod, Request,
-};
+use http::Request;
 use reqwest::{Client, Method};
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha512};
@@ -194,24 +191,17 @@ impl AuthenticatedRequest<'_> {
     /// Returns a tuple of `(signature, signature_input)` strings, or an error if
     /// signature creation fails.
     fn create_signature_headers(&self, req: &reqwest::Request) -> Result<(String, String)> {
-        // Convert to http::Request for signing
+        // Build an http::Request for signing. With reqwest 0.12, the header
+        // and method types are from the same http 1.x crate, so we can use
+        // them directly without manual conversion.
         let mut http_req = Request::new(self.body.clone());
-        *http_req.method_mut() = HttpMethod::from_bytes(req.method().as_str().as_bytes())
-            .map_err(|e| OpClientError::header_parse(format!("Converting HTTP method: {e}")))?;
+        *http_req.method_mut() = req.method().clone();
         *http_req.uri_mut() = req
             .url()
             .as_str()
             .parse()
             .map_err(|e| OpClientError::header_parse(format!("Converting URL to URI: {e}")))?;
-
-        for (key, value) in req.headers() {
-            let header_name = HeaderName::from_bytes(key.as_str().as_bytes())
-                .map_err(|e| OpClientError::header_parse(format!("Converting header name: {e}")))?;
-            let header_value = HeaderValue::from_bytes(value.as_bytes()).map_err(|e| {
-                OpClientError::header_parse(format!("Converting header value: {e}"))
-            })?;
-            http_req.headers_mut().insert(header_name, header_value);
-        }
+        *http_req.headers_mut() = req.headers().clone();
 
         // Create and return signature headers
         let options = SignOptions::new(


### PR DESCRIPTION
## Summary

Upgrades `reqwest` from 0.11 to 0.12, which resolves the `http` crate version mismatch in the project.

**Before:** The project depended on `http = "1.3.1"` but `reqwest = "0.11"` internally used `http 0.2`. This forced manual type conversion between the two `http` crate versions when creating signature headers (converting `Method`, `HeaderName`, `HeaderValue` types one-by-one).

**After:** `reqwest 0.12` uses `http 1.x` natively, matching the project's existing `http` dependency. The conversion boilerplate is replaced with direct `clone()` calls.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | `reqwest` version `0.11` → `0.12` |
| `src/client/request.rs` | Simplify `create_signature_headers` — remove 10 lines of type conversion code |

## Test plan

- [x] All 16 unit tests pass
- [x] All 10 client request tests pass
- [x] All 19 type roundtrip tests pass
- [x] Zero clippy warnings
- [x] Sign → verify round-trip works end-to-end