### PR TITLE
chore: remove unused log dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ url = "2.4"
 # Additional dependencies for HTTP signatures
 pkcs8 = "0.10"
 pem = "3.0"
-log = "0.4"
 rand = "0.8"
 
 # Optional dependencies for snippets


### PR DESCRIPTION
## Summary

The `log` crate (`0.4`) is listed as a dependency in `Cargo.toml` but is never imported or used anywhere in the codebase. Removing it reduces the dependency tree.

Verified with `grep -r "use log\|log::" src/` — zero results.