### PR TITLE
fix(httpsig): require GNAP covered components and verify Content-Digest

### DIFF
--- a/src/http_signature/validation.rs
+++ b/src/http_signature/validation.rs
@@ -1,7 +1,8 @@
 use crate::http_signature::error::{HttpSignatureError, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, Verifier, VerifyingKey};
 use http::{HeaderMap, Request};
+use sha2::{Digest, Sha512};
 
 pub struct ValidationOptions<'a> {
     pub request: &'a Request<Option<String>>,
@@ -99,6 +100,82 @@ fn parse_signature_input(signature_input: &str) -> Result<(Vec<&str>, i64, Strin
     Ok((components, created, keyid))
 }
 
+fn normalize_component(component: &str) -> &str {
+    component.trim().trim_matches('"')
+}
+
+fn request_has_body(request: &Request<Option<String>>) -> bool {
+    match request.body() {
+        Some(body) if !body.is_empty() => true,
+        _ => false,
+    }
+}
+
+/// Enforce Open Payments / GNAP MUST covered components before cryptographic
+/// verification (parity with open-payments-go / open-payments-node).
+fn validate_required_covered_components(
+    request: &Request<Option<String>>,
+    components: &[&str],
+) -> Result<()> {
+    let covered: Vec<&str> = components.iter().map(|c| normalize_component(c)).collect();
+
+    if !covered.iter().any(|c| c.eq_ignore_ascii_case("@method")) {
+        return Err(HttpSignatureError::Validation(
+            "Signature-Input missing required @method component".to_string(),
+        ));
+    }
+    if !covered.iter().any(|c| c.eq_ignore_ascii_case("@target-uri")) {
+        return Err(HttpSignatureError::Validation(
+            "Signature-Input missing required @target-uri component".to_string(),
+        ));
+    }
+    if request.headers().get("Authorization").is_some()
+        && !covered.iter().any(|c| c.eq_ignore_ascii_case("authorization"))
+    {
+        return Err(HttpSignatureError::Validation(
+            "Signature-Input missing required authorization component".to_string(),
+        ));
+    }
+    if request_has_body(request)
+        && !covered.iter().any(|c| c.eq_ignore_ascii_case("content-digest"))
+    {
+        return Err(HttpSignatureError::Validation(
+            "Signature-Input missing required content-digest component for request body"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn content_digest_for_body(body: &str) -> String {
+    let mut hasher = Sha512::new();
+    hasher.update(body.as_bytes());
+    let digest = STANDARD.encode(hasher.finalize());
+    format!("sha-512=:{digest}:")
+}
+
+fn verify_content_digest(request: &Request<Option<String>>) -> Result<()> {
+    let digest_header = request
+        .headers()
+        .get("Content-Digest")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| {
+            HttpSignatureError::Validation("Missing Content-Digest header".to_string())
+        })?;
+
+    let body = request.body().as_ref().ok_or_else(|| {
+        HttpSignatureError::Validation("Missing request body for Content-Digest".to_string())
+    })?;
+
+    let expected = content_digest_for_body(body);
+    if !expected.eq_ignore_ascii_case(digest_header) {
+        return Err(HttpSignatureError::Validation(
+            "Content-Digest does not match request body".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub fn validate_signature(options: ValidationOptions<'_>) -> Result<()> {
     let signature_input = options
         .headers
@@ -109,6 +186,15 @@ pub fn validate_signature(options: ValidationOptions<'_>) -> Result<()> {
         })?;
 
     let (components, created, keyid) = parse_signature_input(signature_input)?;
+
+    validate_required_covered_components(options.request, &components)?;
+
+    if components
+        .iter()
+        .any(|c| normalize_component(c).eq_ignore_ascii_case("content-digest"))
+    {
+        verify_content_digest(options.request)?;
+    }
 
     let signature = options
         .headers
@@ -144,6 +230,18 @@ mod tests {
     use http::{HeaderMap, Method, Request, Uri};
     use rand::rngs::OsRng;
 
+    fn attach_content_headers(request: &mut Request<Option<String>>) {
+        if let Some(body) = request.body().clone() {
+            let digest = content_digest_for_body(&body);
+            request
+                .headers_mut()
+                .insert("Content-Digest", digest.parse().unwrap());
+            request
+                .headers_mut()
+                .insert("Content-Length", body.len().to_string().parse().unwrap());
+        }
+    }
+
     #[test]
     fn test_signature_validation() {
         let mut request = Request::new(Some("test body".to_string()));
@@ -152,6 +250,7 @@ mod tests {
         request
             .headers_mut()
             .insert("Content-Type", "application/json".parse().unwrap());
+        attach_content_headers(&mut request);
 
         let signing_key = SigningKey::generate(&mut OsRng);
         let verifying_key = VerifyingKey::from(&signing_key);
@@ -172,7 +271,7 @@ mod tests {
 
     #[test]
     fn test_missing_signature_input_header() {
-        let mut request = Request::new(Some("body".to_string()));
+        let mut request = Request::new(None);
         *request.method_mut() = Method::POST;
         *request.uri_mut() = Uri::from_static("http://example.com");
 
@@ -192,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_missing_signature_header() {
-        let mut request = Request::new(Some("body".to_string()));
+        let mut request = Request::new(None);
         *request.method_mut() = Method::POST;
         *request.uri_mut() = Uri::from_static("http://example.com");
 
@@ -216,7 +315,7 @@ mod tests {
 
     #[test]
     fn test_base64_decode_failed() {
-        let mut request = Request::new(Some("body".to_string()));
+        let mut request = Request::new(None);
         *request.method_mut() = Method::POST;
         *request.uri_mut() = Uri::from_static("http://example.com");
 
@@ -241,7 +340,7 @@ mod tests {
 
     #[test]
     fn test_invalid_signature_length() {
-        let mut request = Request::new(Some("body".to_string()));
+        let mut request = Request::new(None);
         *request.method_mut() = Method::POST;
         *request.uri_mut() = Uri::from_static("http://example.com");
 
@@ -272,6 +371,7 @@ mod tests {
         request
             .headers_mut()
             .insert("Content-Type", "application/json".parse().unwrap());
+        attach_content_headers(&mut request);
 
         let signing_key = SigningKey::generate(&mut OsRng);
         let verifying_key = VerifyingKey::from(&signing_key);
@@ -291,6 +391,83 @@ mod tests {
         match err {
             HttpSignatureError::Validation(msg) => {
                 assert_eq!(msg, "Signature verification failed");
+            }
+            _ => panic!("unexpected error type"),
+        }
+    }
+
+    #[test]
+    fn test_rejects_under_covered_components_with_body() {
+        let mut request = Request::new(Some(r#"{"amount":"1"}"#.to_string()));
+        *request.method_mut() = Method::POST;
+        *request.uri_mut() = Uri::from_static("https://example.com/resource");
+        request
+            .headers_mut()
+            .insert("Content-Type", "application/json".parse().unwrap());
+        attach_content_headers(&mut request);
+
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let verifying_key = VerifyingKey::from(&signing_key);
+
+        // Cover method/target/type but omit content-digest despite body.
+        let created = 1700000000i64;
+        let keyid = "test-key";
+        let components = ["@method", "@target-uri", "content-type"];
+        let base = create_signature_base_string(&request, &components, created, keyid);
+        let signature = STANDARD.encode(signing_key.sign(base.as_bytes()).to_bytes());
+
+        let mut headers = HeaderMap::new();
+        headers.insert("Signature", signature.parse().unwrap());
+        headers.insert(
+            "Signature-Input",
+            r#"sig1=(@method @target-uri content-type);created=1700000000;keyid="test-key""#
+                .parse()
+                .unwrap(),
+        );
+
+        let err = validate_signature(ValidationOptions::new(&request, &headers, &verifying_key))
+            .unwrap_err();
+        match err {
+            HttpSignatureError::Validation(msg) => {
+                assert!(msg.contains("content-digest"), "unexpected: {msg}");
+            }
+            _ => panic!("unexpected error type"),
+        }
+    }
+
+    #[test]
+    fn test_rejects_body_digest_mismatch() {
+        let mut request = Request::new(Some(r#"{"amount":"1"}"#.to_string()));
+        *request.method_mut() = Method::POST;
+        *request.uri_mut() = Uri::from_static("https://example.com/resource");
+        request
+            .headers_mut()
+            .insert("Content-Type", "application/json".parse().unwrap());
+        attach_content_headers(&mut request);
+
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let verifying_key = VerifyingKey::from(&signing_key);
+        let options = SignOptions::new(&request, &signing_key, "test-key".to_string());
+        let signature_headers = create_signature_headers(options).unwrap();
+
+        // Swap body under the original Content-Digest + Signature headers.
+        *request.body_mut() = Some(r#"{"amount":"999"}"#.to_string());
+        request
+            .headers_mut()
+            .insert("Content-Length", "16".parse().unwrap());
+
+        let mut headers = HeaderMap::new();
+        headers.insert("Signature", signature_headers.signature.parse().unwrap());
+        headers.insert(
+            "Signature-Input",
+            signature_headers.signature_input.parse().unwrap(),
+        );
+
+        let err = validate_signature(ValidationOptions::new(&request, &headers, &verifying_key))
+            .unwrap_err();
+        match err {
+            HttpSignatureError::Validation(msg) => {
+                assert!(msg.contains("Content-Digest"), "unexpected: {msg}");
             }
             _ => panic!("unexpected error type"),
         }


### PR DESCRIPTION
## Summary
- `validate_signature` previously verified whatever `Signature-Input` listed, without enforcing Open Payments / GNAP MUST components.
- With a request body, an attacker could omit `content-digest` (or leave a stale digest) and still get a cryptographically valid signature while swapping the body.
- Enforce `@method`, `@target-uri`, `authorization` (when present), and `content-digest` (when body present), and verify `sha-512` `Content-Digest` against the body.

Parity with [open-payments-go#50](https://github.com/interledger/open-payments-go/pull/50), [open-payments-node#38](https://github.com/interledger/open-payments-node/pull/38), and [open-payments-php#9](https://github.com/interledger/open-payments-php/pull/9).

## Test plan
- [x] `cargo test --lib http_signature::validation` (8/8)
- [ ] CI

Tip: `e136db8` · commit: `3a9a287`

Made with [Cursor](https://cursor.com)